### PR TITLE
Financial Intermediary

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Build # Build Jupyter Book
         shell: bash -l {0}
         run: |
-          pip install jupyter-book
-          pip install sphinxcontrib-bibtex>=2.0.0
           pip install -e .
           cd docs
           jb build ./book

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install jupyter-book
-          pip install sphinxcontrib-bibtex==1.0.0
+          pip install sphinxcontrib-bibtex>=2.0.0
           pip install -e .
           cd docs
           jb build ./book

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install jupyter-book
-          pip install sphinxcontrib-bibtex==1.0.0
+          pip install sphinxcontrib-bibtex>=2.0.0
           pip install -e .
           cd docs
           jb build ./book

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -21,8 +21,6 @@ jobs:
       - name: Build # Build Jupyter Book
         shell: bash -l {0}
         run: |
-          pip install jupyter-book
-          pip install sphinxcontrib-bibtex>=2.0.0
           pip install -e .
           cd docs
           jb build ./book

--- a/docs/book/OGCore_references.bib
+++ b/docs/book/OGCore_references.bib
@@ -133,6 +133,16 @@
   edition = {4th edition},
 }
 
+@TECHREPORT{BenzellEtAl:2017,
+  AUTHOR = {Seth G. Benzell and Laurence J. Kotlikoff and Guillermo LaGarda},
+  TITLE = {Simulating Business Cash Flow Taxation: An Illustration Based on the ``Better Way'' Corporate Tax Reform},
+  INSTITUTION = {National Bureau of Economic Research},
+  YEAR = {2017},
+  type = {NBER Working Paper},
+  number = {23675},
+  month = {August},
+}
+
 @ARTICLE{BrummGrill:2014,
   AUTHOR = {Johannes Brumm and Michael Grill},
   TITLE = {Computing Equilibria in Dynamic Models with Occasionally Binding Constraints},
@@ -155,8 +165,6 @@ abstract = {The budget constraint requires that, eventually, consumption must ad
 keywords = {Risk Uncertainty Consumption Precautionary saving Buffer-stock saving Permanent income hypothesis},
 url = {https://EconPapers.repec.org/RePEc:eee:moneco:v:56:y:2009:i:6:p:780-790}
 }
-
-
 
 @Article{ABMW:1999,
   author={Orazio P. Attanasio and James Banks and Costas Meghir and and Guglielmo Weber},

--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -50,6 +50,8 @@ sphinx:
                                'sphinx.ext.viewcode', 'sphinx.ext.napoleon',
                                'alabaster']   # A list of extra extensions to load by Sphinx.
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration
+    bibtex_reference_style: author_year
+    mathjax_path          : https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 ####################################################
 # LaTeX information

--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -14,8 +14,9 @@ parts:
   - file: content/theory/households
   - file: content/theory/firms
   - file: content/theory/government
-  - file: content/theory/market_clearing
   - file: content/theory/open_economy
+  - file: content/theory/financial
+  - file: content/theory/market_clearing
   - file: content/theory/stationarization
   - file: content/theory/equilibrium
 - caption: Appendix

--- a/docs/book/content/api/aggregates.rst
+++ b/docs/book/content/api/aggregates.rst
@@ -9,5 +9,5 @@ ogcore.aggregates
 ------------------------------------------
 
 .. automodule:: ogcore.aggregates
-  :members: get_L, get_I, get_B, get_BQ, get_C, revenue, get_r_hh,
+  :members: get_L, get_I, get_B, get_BQ, get_C, revenue, get_r_p,
     resource_constraint, get_K_splits

--- a/docs/book/content/theory/equilibrium.md
+++ b/docs/book/content/theory/equilibrium.md
@@ -333,7 +333,7 @@ We call this solution algorithm the time path iteration (TPI) method or transiti
 
 The key assumption is that the economy will reach the steady-state equilibrium $\boldsymbol{\bar{\Gamma}}$ described in {ref}`SecEqlbSSdef` in a finite number of periods $T<\infty$ regardless of the initial state $\boldsymbol{\hat{\Gamma}}_1$. The first step in solving for the non-steady-state equilibrium transition path is to solve for the steady-state using the method described in Section {ref}`SecEqlbSSsoln`. After solving for the steady-state, one must then find a fixed point over the entire time path or transition path of endogenous objects that satisfies the characterizing equilibrium equations in every period.
 
-The non-steady-state solution algorithm follows the steps below. We again use a notational convention of a subscript $a$ or a subscript $b$ in steps (?) and (?) to differentiate between the same inner-loop variables computed two different ways at two different stages of the algorithm ($\hat{w}_{t,a}$, $\hat{w}_{t,b}$, $r_{gov,t,a}$, $r_{gov,t,b}$, $r_{hh,t,a}$, $r_{hh,t,b}$, $\hat{Y}_{t,a}$, $\hat{Y}_{t,b}$, $\hat{K}_{t,a}$, $\hat{K}_{t,b}$).
+The non-steady-state solution algorithm follows the steps below. We again use a notational convention of a subscript $a$ or a subscript $b$ in steps (?) and (?) to differentiate between the same inner-loop variables computed two different ways at two different stages of the algorithm ($\hat{w}_{t,a}$, $\hat{w}_{t,b}$, $r_{gov,t,a}$, $r_{gov,t,b}$, $r_{p,t,a}$, $r_{p,t,b}$, $\hat{Y}_{t,a}$, $\hat{Y}_{t,b}$, $\hat{K}_{t,a}$, $\hat{K}_{t,b}$).
 
 We outline the stationary non-steady state (transition path) solution algorithm in the following steps.
 
@@ -349,7 +349,7 @@ We outline the stationary non-steady state (transition path) solution algorithm 
 
         1. Solve for the transition path of $r_{gov,t}$ using equation {eq}`EqUnbalGBC_rate_wedge`.
 
-        2. Solve for the transition path of $r_{hh,t}$ using equation {eq}`EqStnrz_rate_hh`.
+        2. Solve for the transition path of $r_{p,t}$ using equation {eq}`EqStnrz_rate_hh`.
 
 3. Given initial condition $\boldsymbol{\hat{\Gamma}}_1$, guesses for the aggregate time paths $\{\boldsymbol{r}^i,\boldsymbol{\hat{BQ}}^i, \boldsymbol{\hat{TR}}^i\}$, we solve for the inner loop lifetime decisions of every household that will be alive across the time path $\{n_{j,s,t},\hat{b}_{j,s+1,t+1}\}_{s=E+1}^{E+S}$ for all $j$ and $1\leq t\leq T$.
 

--- a/docs/book/content/theory/financial.md
+++ b/docs/book/content/theory/financial.md
@@ -1,0 +1,50 @@
+
+(Chap_FinInt)=
+
+# Financial Intermediary
+
+Domestic household wealth, $W^d_{t}=B_{t}$, and foreign ownership of domestic assets, $W^f_{t}$, are invested in a financial intermediary. This intermediary purchases a portfolio of government bonds and private capital in accordance with the domestic and foreign investor demand for these assets and then returns a single portfolio rate of return to all investors.
+
+Foreign demand for government bonds is specified in {ref}`SecMarkClrMktClr_G`:
+
+  ```{math}
+  :label: EqMarkClr_zetaD2
+    D^{f}_{t+1} = D^{f}_{t} + \zeta_{D}(D_{t+1} - D_{t}) \quad\forall t
+  ```
+
+This leaves domestic investors to buy up the residual amount of government debt:
+
+  ```{math}
+  :label: EqMarkClr_zetaD2
+    D^{d}_{t} = D_{t} - D^{f}_{t} \quad\forall t
+  ```
+
+We assume that debt dominates the capital markets, such that domestic investor demand for capital, $K^{d}_{t}$ is given as:
+
+  ```{math}
+  :label: eq_domestic_cap_demand
+    K^{d}_{t} = B_{t} - D^{d}_{t} \quad\forall t
+  ```
+
+Foreign demand for capital is given in {ref}`SecMarkClrMktClr_K`, where $K^{f}_{t}$ is an exogenous fraction of excess capital demand at the world interest rate:
+
+  ```{math}
+  :label: eq_foreign_cap_demand
+    K^{f}_t = \zeta_{K}ED^{K,r^*}_t \quad\forall t
+  ```
+
+The total amount invested in the financial intermediary is thus:
+
+```{math}
+W_{t} & = W^d_{t} + W^f_{t} \\
+    & = D^d_t + K^d_t  + D^f_t + K^f_t \\
+    & = D_t + K_t
+```
+
+Interest rates on private capital and government bonds differ.  The return on the portfolio of assets held in the financial intermediary is the weighted average of these two rates of return:
+
+```{math}
+:label: eq_portfolio_return
+r_{p,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}} \quad\forall t
+```
+

--- a/docs/book/content/theory/financial.md
+++ b/docs/book/content/theory/financial.md
@@ -3,9 +3,9 @@
 
 # Financial Intermediary
 
-Domestic household wealth, $W^d_{t}=B_{t}$, and foreign ownership of domestic assets, $W^f_{t}$, are invested in a financial intermediary. This intermediary purchases a portfolio of government bonds and private capital in accordance with the domestic and foreign investor demand for these assets and then returns a single portfolio rate of return to all investors.
+Domestic household wealth, $W^d_{t}=B_{t}$ and foreign ownership of domestic assets $W^f_{t}$ are invested in a financial intermediary. This intermediary purchases a portfolio of government bonds and private capital in accordance with the domestic and foreign investor demand for these assets and then returns a single portfolio rate of return to all investors.
 
-Foreign demand for government bonds is specified in {ref}`SecMarkClrMktClr_G`:
+Foreign demand for government bonds is specified in section {ref}`SecMarkClrMktClr_G` of the {ref}`Chap_MarkClr` chapter:
 
   ```{math}
   :label: EqMarkClr_zetaD2
@@ -47,4 +47,3 @@ Interest rates on private capital and government bonds differ.  The return on th
 :label: eq_portfolio_return
 r_{p,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}} \quad\forall t
 ```
-

--- a/docs/book/content/theory/government.md
+++ b/docs/book/content/theory/government.md
@@ -12,7 +12,7 @@ In `OG-Core`, the government enters by levying taxes on households, providing tr
 
   ```{math}
   :label: EqHHBC
-    c_{j,s,t} + b_{j,s+1,t+1} &= (1 + r_{hh,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{BQ_t}{\lambda_j\omega_{s,t}} + \eta_{j,s,t}\frac{TR_{t}}{\lambda_j\omega_{s,t}} + ubi_{j,s,t} - T_{s,t}  \\
+    c_{j,s,t} + b_{j,s+1,t+1} &= (1 + r_{p,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{BQ_t}{\lambda_j\omega_{s,t}} + \eta_{j,s,t}\frac{TR_{t}}{\lambda_j\omega_{s,t}} + ubi_{j,s,t} - T_{s,t}  \\
     &\quad\forall j,t\quad\text{and}\quad s\geq E+1 \quad\text{where}\quad b_{j,E+1,t}=0\quad\forall j,t
   ```
 
@@ -30,7 +30,7 @@ In `OG-Core`, the government enters by levying taxes on households, providing tr
     Rev_t = \underbrace{\tau^{corp}\bigl[Y_t - w_t L_t\bigr] - \tau^{corp}\delta^\tau K_t}_{\text{corporate tax revenue}} + \underbrace{\sum_{s=E+1}^{E+S}\sum_{j=1}^J\lambda_j\omega_{s,t}\tau^{etr}_{s,t}\left(x_{j,s,t},y_{j,s,t}\right)\bigl(x_{j,s,t} + y_{j,s,t}\bigr)}_{\text{household tax revenue}} \quad\forall t
   ```
 
-  where household labor income is defined as $x_{j,s,t}\equiv w_t e_{j,s}n_{j,s,t}$ and capital income $y_{j,s,t}\equiv r_{hh,t} b_{j,s,t}$.
+  where household labor income is defined as $x_{j,s,t}\equiv w_t e_{j,s}n_{j,s,t}$ and capital income $y_{j,s,t}\equiv r_{p,t} b_{j,s,t}$.
 
 (SecUnbalGBCbudgConstr)=
 ## Government Budget Constraint

--- a/docs/book/content/theory/government.md
+++ b/docs/book/content/theory/government.md
@@ -79,16 +79,7 @@ In `OG-Core`, the government enters by levying taxes on households, providing tr
     r_{gov, t} = (1 - \tau_{d, t})r_{t} - \mu_{d}
   ```
 
-  where $r_t$ is the marginal product of capital faced by firms. The two parameters, $\tau_{d,t}$ and $\mu_{d,t}$ can be used to allow for a government interest rate that is a percentage hair cut from the market rate or a government interest rate with a constant risk premia.
-
-  In the cases where there is a differential ($\tau_{d,t}$ or $\mu_{d,t} \neq 0$), then we need to be careful to specify how the household chooses government debt and private capital in its portfolio of asset holdings. We make the assumption that under the exogenous interest rate wedge, the household is indifferent between holding its assets as debt and private capital. This amounts to an assumption that these two assets are perfect substitutes given the exogenous wedge in interest rates. Given the indifference between government debt and private capital at these two interest rates, we assume that the household holds debt and capital in the same ratio that debt and capital are demanded by the government and private firms, respectively. The interest rate on the household portfolio of asset is thus given by:
-
-  ```{math}
-    :label: EqUnbalGBC_rate_hh
-    r_{hh,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}} \quad\forall t
-  ```
-
-  It is technically more correct to assume that the domestic households return to savings $r_{hh,t}$ is a function of the amount of domestic household savings allocated to private capital $K^d_t$ and the amount allocated to government debt $D^d_t$. However, this would require us to add another state variable to the model, which would exponentially increase the difficulty and computation time of the equilibrium solution method. The characterization of the household savings rate of return in {eq}`EqUnbalGBC_rate_hh` as a function of total government debt $D_t$ and total private captial $K_t$ is a simplifying assumption.
+  where $r_t$ is the marginal product of capital faced by firms. The two parameters, $\tau_{d,t}$ and $\mu_{d,t}$ can be used to allow for a government interest rate that is a percentage hair cut from the market rate or a government interest rate with a constant risk premium.
 
 
 (SecUnbalGBCcloseRule)=

--- a/docs/book/content/theory/households.md
+++ b/docs/book/content/theory/households.md
@@ -27,12 +27,12 @@ In this section, we describe what is arguably the most important economic agent 
 
   ```{math}
   :label: EqHHBC
-    c_{j,s,t} + b_{j,s+1,t+1} &= (1 + r_{hh,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \\
+    c_{j,s,t} + b_{j,s+1,t+1} &= (1 + r_{p,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \\
     &\quad\quad\zeta_{j,s}\frac{BQ_t}{\lambda_j\omega_{s,t}} + \eta_{j,s,t}\frac{TR_{t}}{\lambda_j\omega_{s,t}} + ubi_{j,s,t} - T_{s,t}  \\
     &\quad\forall j,t\quad\text{and}\quad s\geq E+1 \quad\text{where}\quad b_{j,E+1,t}=0\quad\forall j,t
   ```
 
-  where $c_{j,s,t}$ is consumption, $b_{j,s+1,t+1}$ is savings for the next period, $r_{hh,t}$ is the interest rate (return) on household savings, $b_{j,s,t}$ is current period wealth (savings from last period), $w_t$ is the wage, and $n_{j,s,t}$ is labor supply. Equation {eq}`EqUnbalGBC_rate_hh` of Section {ref}`SecRateWedge` of Chapter {ref}`Chap_UnbalGBC` derives why this household interest rate $r_{hh,t}$ might differ from the marginal product of capital $r_t$ and from the interest rate the government pays $r_{gov,t}$.
+  where $c_{j,s,t}$ is consumption, $b_{j,s+1,t+1}$ is savings for the next period, $r_{p,t}$ is the interest rate (return) on household savings invested in the financial intermediary, $b_{j,s,t}$ is current period wealth (savings from last period), $w_t$ is the wage, and $n_{j,s,t}$ is labor supply. Equation {eq}`eq_portfolio_return` of Chapter {ref}`Chap_FinInt` shows how the rate of return from the financial intermediary, $r_{p,t}$ might differ from the marginal product of capital $r_t$ and from the interest rate the government pays $r_{gov,t}$.
 
   The next term on the right-hand-side of the budget constraint {eq}`EqHHBC` represents the portion of total bequests $BQ_t$ that go to the age-$s$, income-group-$j$ household. Let $\zeta_{j,s}$ be the fraction of total bequests $BQ_t$ that go to the age-$s$, income-group-$j$ household, such that $\sum_{s=E+1}^{E+S}\sum_{j=1}^J\zeta_{j,s}=1$. We must divide that amount by the population of $(j,s)$ households $\lambda_j\omega_{s,t}$. The calibration chapter on beqests in the country-specific repository documentation details how to calibrate the $\zeta_{j,s}$ values from consumer finance data.
 
@@ -40,7 +40,7 @@ In this section, we describe what is arguably the most important economic agent 
 
   The term $ubi_{j,s,t}$ the time series of a matrix of universal basic income (UBI) transfers by lifetime income group $j$ and age group $s$ in each period $t$. There is a specification where the time series of this matrix is stationary (growth adjusted) and a specification in which it's stationary value is going to zero in the limit (non-growth-adjusted). The calibration chapter on UBI in the country-specific repository documentation describes the exact way in which this matrix is calibrated from the values of five parameters, household composition data, and OG-Core's demographics. Similar to the transfers term $TR_{t}$, the UBI transfers will not be distortionary.
 
-  The term $T_{s,t}$ is the total tax liability of the household. In contrast to government transfers $tr_{j,s,t}$, tax liability can be a function of labor income $(x_{j,s,t}\equiv w_t e_{j,s}n_{j,s,t})$ and capital income $(y_{j,s,t}\equiv r_{hh,t} b_{j,s,t})$. The tax liability can, therefore, be a distortionary influence on household decisions. It becomes valuable to represent total tax liability as an effective tax rate $\tau^{etr}$ multiplied by total income,
+  The term $T_{s,t}$ is the total tax liability of the household. In contrast to government transfers $tr_{j,s,t}$, tax liability can be a function of labor income $(x_{j,s,t}\equiv w_t e_{j,s}n_{j,s,t})$ and capital income $(y_{j,s,t}\equiv r_{p,t} b_{j,s,t})$. The tax liability can, therefore, be a distortionary influence on household decisions. It becomes valuable to represent total tax liability as an effective tax rate $\tau^{etr}$ multiplied by total income,
 
   ```{math}
   :label: EqTaxCalcLiabETR
@@ -128,7 +128,7 @@ In this section, we describe what is arguably the most important economic agent 
 
   ```{math}
   :label: EqHHBC2
-    &\quad\text{s.t.}\quad c_{j,s,t} + b_{j,s+1,t+1} = (1 + r_{hh,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{BQ_t}{\lambda_j\omega_{s,t}} + \eta_{j,s,t}\frac{TR_{t}}{\lambda_j\omega_{s,t}} + ubi_{j,s,t} - T_{s,t} \\
+    &\quad\text{s.t.}\quad c_{j,s,t} + b_{j,s+1,t+1} = (1 + r_{p,t})b_{j,s,t} + w_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{BQ_t}{\lambda_j\omega_{s,t}} + \eta_{j,s,t}\frac{TR_{t}}{\lambda_j\omega_{s,t}} + ubi_{j,s,t} - T_{s,t} \\
     &\qquad\text{and}\quad c_{j,s,t}\geq 0,\: n_{j,s,t} \in[0,\tilde{l}],\:\text{and}\: b_{j,1,t}=0 \quad\forall j, t, \:\text{and}\: E+1\leq s\leq E+S \nonumber
   ```
 
@@ -144,7 +144,7 @@ In this section, we describe what is arguably the most important economic agent 
 
   ```{math}
   :label: EqHHeul_b
-    &(c_{j,s,t})^{-\sigma} = \chi^b_j\rho_s(b_{j,s+1,t+1})^{-\sigma} + \beta_j\bigl(1 - \rho_s\bigr)\Bigl(1 + r_{hh,t+1}\bigl[1 - \tau^{mtry}_{s+1,t+1}\bigr]\Bigr)(c_{j,s+1,t+1})^{-\sigma} \\
+    &(c_{j,s,t})^{-\sigma} = \chi^b_j\rho_s(b_{j,s+1,t+1})^{-\sigma} + \beta_j\bigl(1 - \rho_s\bigr)\Bigl(1 + r_{p,t+1}\bigl[1 - \tau^{mtry}_{s+1,t+1}\bigr]\Bigr)(c_{j,s+1,t+1})^{-\sigma} \\
     &\qquad\qquad\qquad\qquad\qquad\qquad\qquad\qquad\forall j,t, \quad\text{and}\quad E+1\leq s\leq E+S-1 \\
   ```
 
@@ -162,7 +162,7 @@ In this section, we describe what is arguably the most important economic agent 
 
   ```{math}
   :label: EqMTRy_derive
-    \frac{\partial T_{s,t}}{\partial b_{j,s,t}} = \frac{\partial T_{s,t}}{\partial r_{hh,t}b_{j,s,t}}\frac{\partial r_{hh,t} b_{j,s,t}}{\partial b_{j,s,t}} = \frac{\partial T_{s,t}}{\partial r_{hh,t} b_{j,s,t}}r_{hh,t} = \tau^{mtry}_{s,t}r_{hh,t}
+    \frac{\partial T_{s,t}}{\partial b_{j,s,t}} = \frac{\partial T_{s,t}}{\partial r_{p,t}b_{j,s,t}}\frac{\partial r_{p,t} b_{j,s,t}}{\partial b_{j,s,t}} = \frac{\partial T_{s,t}}{\partial r_{p,t} b_{j,s,t}}r_{p,t} = \tau^{mtry}_{s,t}r_{p,t}
   ```
 
 (SecHHexp)=

--- a/docs/book/content/theory/market_clearing.md
+++ b/docs/book/content/theory/market_clearing.md
@@ -71,7 +71,7 @@ We also characterize here the law of motion for total bequests $BQ_t$. Although 
     K_t = K^d_t + K^f_t \quad\forall t
   ```
 
-  Assume that there exists some exogenous world interest rate $r^*_t$. We assume that foreign capital supply $K^f_t$ is an exogenous percentage $\zeta_K\in[0,1]$ of the excess total domestic private capital demand $ED^{K,r^*}_t$ that would exist if domestic private capital demand were determined by the exogenous world interest rate $r^*_t$ and domestic private capital supply were determined by the model consistent return on household savings $r_{hh,t}$. This percentage $\zeta_K$ is something we calibrate. Define excess total domestic capital demand at the exogenous world interest rate $r^*_t$ as $ED^{K,r^*}_t$. Define $K^{r^*}_t$ as the capital demand by domestic firms at the world interest rate $r^*_t$, and define $K^{d}_t$ as the domestic supply of private capital to firms, which is modeled as being a function of the actual rate faced by households $r_{hh,t}$. Then our measure of excess demand at the world interest rate is the following.
+  Assume that there exists some exogenous world interest rate $r^*_t$. We assume that foreign capital supply $K^f_t$ is an exogenous percentage $\zeta_K\in[0,1]$ of the excess total domestic private capital demand $ED^{K,r^*}_t$ that would exist if domestic private capital demand were determined by the exogenous world interest rate $r^*_t$ and domestic private capital supply were determined by the model consistent return on household savings $r_{p,t}$. This percentage $\zeta_K$ is something we calibrate. Define excess total domestic capital demand at the exogenous world interest rate $r^*_t$ as $ED^{K,r^*}_t$. Define $K^{r^*}_t$ as the capital demand by domestic firms at the world interest rate $r^*_t$, and define $K^{d}_t$ as the domestic supply of private capital to firms, which is modeled as being a function of the actual rate faced by households $r_{p,t}$. Then our measure of excess demand at the world interest rate is the following.
 
   ```{math}
   :label: EqMarkClr_ExDemK
@@ -100,7 +100,7 @@ We also characterize here the law of motion for total bequests $BQ_t$. Although 
   ```{math}
   :label: EqMarkClrGoods
     \begin{split}
-      Y_t &= C_t + \bigl(K^d_{t+1} - K^d_t\bigr) + \delta K_t + G_t + r_{hh,t} K^f_t - \bigl(D^f_{t+1} - D^f_t\bigr) + r_{hh,t}D^f_t \quad\forall t \\
+      Y_t &= C_t + \bigl(K^d_{t+1} - K^d_t\bigr) + \delta K_t + G_t + r_{p,t} K^f_t - \bigl(D^f_{t+1} - D^f_t\bigr) + r_{p,t}D^f_t \quad\forall t \\
       &\quad\text{where}\quad C_t \equiv \sum_{s=E+1}^{E+S}\sum_{j=1}^{J}\omega_{s,t}\lambda_j c_{j,s,t}
     \end{split}
   ```
@@ -115,7 +115,7 @@ We also characterize here the law of motion for total bequests $BQ_t$. Although 
 
   ```{math}
   :label: EqMarkClrBQ
-    BQ_{t} = (1+r_{hh,t})\left(\sum_{s=E+2}^{E+S+1}\sum_{j=1}^J\rho_{s-1}\lambda_j\omega_{s-1,t-1}b_{j,s,t}\right) \quad\forall t
+    BQ_{t} = (1+r_{p,t})\left(\sum_{s=E+2}^{E+S+1}\sum_{j=1}^J\rho_{s-1}\lambda_j\omega_{s-1,t-1}b_{j,s,t}\right) \quad\forall t
   ```
 
   Because the form of the period utility function in {eq}`EqHHPerUtil` ensures that $b_{j,s,t}>0$ for all $j$, $s$, and $t$, total bequests will always be positive $BQ_{j,t}>0$ for all $j$ and $t$.
@@ -125,4 +125,4 @@ We also characterize here the law of motion for total bequests $BQ_t$. Although 
 ## Footnotes
 
 [^indif_KD_note]: By assuming that households are indifferent between the savings allocation to private capital $K^d_t$ and government bonds $D^d_t$, we avoid the need for another state variable in the solution method. In our approach the allocation between the two types of capital is simply a residual of the exogenous proportion $\zeta_K$ of total private captial $K_t$ allocated to foreigners implied by equations {eq}`EqMarkClr_zetaK` and {eq}`EqMarkClr_KtKdKf` and a residual of the exogenous proportion $\zeta_D$ of total government bonds $D_t$ allocated to foreigners implied by equations {eq}`EqMarkClr_zetaD` and {eq}`EqMarkClr_DtDdDf`.
-[^RCrates_note]: Because we treat household return $r_{hh,t}$ as an average between the return on private capital $r_t$ and the return on government bonds $r_{gov,t}$ in {eq}`EqUnbalGBC_rate_hh`, and because this return is actually given to households in the budget constraint {eq}`EqHHBC2`, it is required for market clearing that the return paid to foreign suppliers of private capital $K^f_t$ and foreign holders of government bonds $D^f_t$ be paid that same average return $r_{hh,t}$.
+[^RCrates_note]: Because we treat household return $r_{p,t}$ as an average between the return on private capital $r_t$ and the return on government bonds $r_{gov,t}$ in {eq}`EqUnbalGBC_rate_hh`, and because this return is actually given to households in the budget constraint {eq}`EqHHBC2`, it is required for market clearing that the return paid to foreign suppliers of private capital $K^f_t$ and foreign holders of government bonds $D^f_t$ be paid that same average return $r_{p,t}$.

--- a/docs/book/content/theory/market_clearing.md
+++ b/docs/book/content/theory/market_clearing.md
@@ -87,7 +87,7 @@ We also characterize here the law of motion for total bequests $BQ_t$. Although 
 
   This approach nicely nests the small open economy specification discussed in Section {ref}`SecSmallOpen` of Chapter {ref}`Chap_SmOpEcn` in which $\zeta_K=1$, foreigners flexibly supply all the excess demand for private capital, the marginal product of capital is fixed at the exogenous world interest rate $r^*$, and domestic households face the least amount of crowd out by government debt. The opposite extreme is the closed private capital market assumption of $\zeta_K=0$ in which $K^f_t=0$ and households must supply all the capital demanded in the domestic market. In this specification, the interest rate is the most flexible and adjusts to equilibrate domestic private capital supply $K^d_t$ with private capital demand $K_t$.
 
-  For the interemediate specifications of $\zeta_K\in(0,1)$, foreigners provide a fraction of the excess demand defined in {eq}`EqMarkClr_ExDemK`. This allows for partial inflows of foreign private capital, partial crowd-out of government spending on private investment, and partial adjustment of the domestic interest rate $r_t$. This latter set of model specifications could be characterized as large-open economy or partial capital mobility.
+  For the intermediate specifications of $\zeta_K\in(0,1)$, foreigners provide a fraction of the excess demand defined in {eq}`EqMarkClr_ExDemK`. This allows for partial inflows of foreign private capital, partial crowd-out of government spending on private investment, and partial adjustment of the domestic interest rate $r_t$. This latter set of model specifications could be characterized as large-open economy or partial capital mobility.
 
 
   (SecMarkClrMktClr_goods)=

--- a/docs/book/content/theory/open_economy.md
+++ b/docs/book/content/theory/open_economy.md
@@ -1,7 +1,7 @@
 (Chap_SmOpEcn)=
 # Open Economy Options
 
-`OG-Core` offers a wide range of specifications regarding the type and degree of openness assumed in the economy. In none of our specifications do we fully model foreign economies as is done by (Kotlikoff cites) and others. However, one of the findings of (Kotlikoff) is that a full multi-country model is closely approximated by the types of large partial open economy specifications we use in `OG-Core`. Our specifications range from fully closed, to partially closed, to small open economy, to large open economy. We discussed some of these specifications in the previous chapter {ref}`Chap_MarkClr`. But the open economy assumptions only refer to how foreign capital can flow into the private capital market $K_t$ and into the government bond market $D_t$. The labor market and goods market are closed.
+`OG-Core` offers a wide range of specifications regarding the type and degree of openness assumed in the economy. In none of our specifications do we fully model foreign economies as is done by {cite}`BenzellEtAl:2017` and others. However, one of the findings of {cite}`BenzellEtAl:2017` is that a full multi-country model is closely approximated by the types of large partial open economy specifications we use in `OG-Core`. Our specifications range from fully closed, to partially closed, to small open economy, to large open economy. We discussed some of these specifications in the previous chapter {ref}`Chap_MarkClr`. But the open economy assumptions only refer to how foreign capital can flow into the private capital market $K_t$ and into the government bond market $D_t$. The labor market and goods market are closed.
 
 (SecSmallOpen)=
 ## Small Open Economy

--- a/docs/book/content/theory/stationarization.md
+++ b/docs/book/content/theory/stationarization.md
@@ -28,7 +28,7 @@ The previous chapters derive all the equations necessary to solve for the steady
 * - $\hat{w}_t\equiv \frac{w_t}{e^{g_y t}}$
   -
   - $\hat{BQ}_{j,t}\equiv\frac{BQ_{j,t}}{e^{g_y t}\tilde{N}_t}$
-  - $r_{hh,t}$
+  - $r_{p,t}$
 * - $\hat{y}_{j,s,t}\equiv \frac{y_{j,s,t}}{e^{g_y t}}$
   -
   - $\hat{C}_t\equiv\frac{C_t}{e^{g_y t}\tilde{N}_t}$
@@ -57,7 +57,7 @@ The usual definition of equilibrium would be allocations and prices such that ho
 
   ```{math}
   :label: EqStnrzHHBCstat
-    \hat{c}_{j,s,t} + e^{g_y}\hat{b}_{j,s+1,t+1} &= (1 + r_{hh,t})\hat{b}_{j,s,t} + \hat{w}_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{\hat{BQ}_t}{\lambda_j\hat{\omega}_{s,t}} + \eta_{j,s,t}\frac{\hat{TR}_{t}}{\lambda_j\hat{\omega}_{s,t}} + \hat{ubi}_{j,s,t} - \hat{T}_{s,t}  \\
+    \hat{c}_{j,s,t} + e^{g_y}\hat{b}_{j,s+1,t+1} &= (1 + r_{p,t})\hat{b}_{j,s,t} + \hat{w}_t e_{j,s} n_{j,s,t} + \zeta_{j,s}\frac{\hat{BQ}_t}{\lambda_j\hat{\omega}_{s,t}} + \eta_{j,s,t}\frac{\hat{TR}_{t}}{\lambda_j\hat{\omega}_{s,t}} + \hat{ubi}_{j,s,t} - \hat{T}_{s,t}  \\
     &\quad\forall j,t\quad\text{and}\quad s\geq E+1 \quad\text{where}\quad \hat{b}_{j,E+1,t}=0
   ```
 
@@ -75,7 +75,7 @@ The usual definition of equilibrium would be allocations and prices such that ho
 
   ```{math}
   :label: EqStnrzHHeul_b
-    (\hat{c}_{j,s,t})^{-\sigma} = e^{-\sigma g_y}\biggl[\chi^b_j\rho_s(\hat{b}_{j,s+1,t+1})^{-\sigma} + \beta_j\bigl(1 - \rho_s\bigr)\Bigl(1 + r_{hh,t+1}\bigl[1 - \tau^{mtry}_{s+1,t+1}\bigr]\Bigr)(\hat{c}_{j,s+1,t+1})^{-\sigma}\biggr] \\
+    (\hat{c}_{j,s,t})^{-\sigma} = e^{-\sigma g_y}\biggl[\chi^b_j\rho_s(\hat{b}_{j,s+1,t+1})^{-\sigma} + \beta_j\bigl(1 - \rho_s\bigr)\Bigl(1 + r_{p,t+1}\bigl[1 - \tau^{mtry}_{s+1,t+1}\bigr]\Bigr)(\hat{c}_{j,s+1,t+1})^{-\sigma}\biggr] \\
     \qquad\qquad\qquad\qquad\qquad\qquad\qquad\qquad\forall j,t, \quad\text{and}\quad E+1\leq s\leq E+S-1 \\
   ```
 
@@ -141,7 +141,7 @@ The usual definition of equilibrium would be allocations and prices such that ho
   ```{math}
   :label: EqStnrzLiabETR
     \hat{T}_{s,t} &= \tau^{etr}_{s,t}(\hat{x}_{j,s,t}, \hat{y}_{j,s,t})\left(\hat{x}_{j,s,t} + \hat{y}_{j,s,t}\right) \qquad\qquad\qquad\qquad\forall t \quad\text{and}\quad E+1\leq s\leq E+S \\
-    &= \tau^{etr}_{s,t}(\hat{w}_t e_{j,s}n_{j,s,t}, r_{hh,t}\hat{b}_{j,s,t})\left(\hat{w}_t e_{j,s}n_{j,s,t} + r_{hh,t}\hat{b}_{j,s,t}\right) \quad\forall t \quad\text{and}\quad E+1\leq s\leq E+S
+    &= \tau^{etr}_{s,t}(\hat{w}_t e_{j,s}n_{j,s,t}, r_{p,t}\hat{b}_{j,s,t})\left(\hat{w}_t e_{j,s}n_{j,s,t} + r_{p,t}\hat{b}_{j,s,t}\right) \quad\forall t \quad\text{and}\quad E+1\leq s\leq E+S
   ```
 
   We can stationarize the simple expressions for total government spending on public goods $G_t$ in {eq}`EqUnbalGBC_Gt` and on household transfers $TR_t$ in {eq}`EqUnbalGBCtfer` by dividing both sides by $e^{g_y t}\tilde{N}_t$,
@@ -177,11 +177,11 @@ The usual definition of equilibrium would be allocations and prices such that ho
     \hat{UBI}_t \equiv \sum_{s=E+1}^{E+S}\sum_{j=1}^J \lambda_j\hat{\omega}_{s,t} \hat{ubi}_{j,s,t} \quad\forall t
   ```
 
-  The expression for the interest rate on government debt $r_{gov,t}$ in {eq}`EqUnbalGBC_rate_wedge` is already stationary because every term on the right-hand-side is already stationary. The expression for the return to household savings $r_{hh,t}$ in {eq}`EqUnbalGBC_rate_hh` is equivalent to its stationary representation because the same macroeconomic variables occur linearly in both the numerator and denominator.
+  The expression for the interest rate on government debt $r_{gov,t}$ in {eq}`EqUnbalGBC_rate_wedge` is already stationary because every term on the right-hand-side is already stationary. The expression for the return to household savings $r_{p,t}$ in {eq}`EqUnbalGBC_rate_hh` is equivalent to its stationary representation because the same macroeconomic variables occur linearly in both the numerator and denominator.
 
   ```{math}
     :label: EqStnrz_rate_hh
-    r_{hh,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}} = \frac{r_{gov,t}\hat{D}_{t} + r_{t}\hat{K}_{t}}{\hat{D}_{t} + \hat{K}_{t}} \quad\forall t
+    r_{p,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}} = \frac{r_{gov,t}\hat{D}_{t} + r_{t}\hat{K}_{t}}{\hat{D}_{t} + \hat{K}_{t}} \quad\forall t
   ```
 
   The long-run debt-to-GDP ratio condition is also the same in both the nonstationary version in {eq}`EqUnbalGBC_DY` as well as the stationary version below because the endogenous side is a ratio of macroeconomic variables that are growing at the same rate.
@@ -294,7 +294,7 @@ The usual definition of equilibrium would be allocations and prices such that ho
   ```{math}
   :label: EqStnrzMarkClrGoods
     \begin{split}
-      \hat{Y}_t &= \hat{C}_t + \Bigl(e^{g_y}\bigl[1 + \tilde{g}_{n,t+1}\bigr]\hat{K}^d_{t+1} - \hat{K}^d_t\Bigr) + \delta\hat{K}_t + \hat{G}_t + r_{hh,t}\hat{K}^f_t - \Bigl(e^{g_y}\bigl[1 + \tilde{g}_{n,t+1}\bigr]\hat{D}^f_{t+1} - \hat{D}^f_t\Bigr) + r_{hh,t}\hat{D}^f_t \quad\forall t \\
+      \hat{Y}_t &= \hat{C}_t + \Bigl(e^{g_y}\bigl[1 + \tilde{g}_{n,t+1}\bigr]\hat{K}^d_{t+1} - \hat{K}^d_t\Bigr) + \delta\hat{K}_t + \hat{G}_t + r_{p,t}\hat{K}^f_t - \Bigl(e^{g_y}\bigl[1 + \tilde{g}_{n,t+1}\bigr]\hat{D}^f_{t+1} - \hat{D}^f_t\Bigr) + r_{p,t}\hat{D}^f_t \quad\forall t \\
       &\quad\text{where}\quad \hat{C}_t \equiv \sum_{s=E+1}^{E+S}\sum_{j=1}^{J}\hat{\omega}_{s,t}\lambda_j\hat{c}_{j,s,t}
     \end{split}
   ```
@@ -303,5 +303,5 @@ The usual definition of equilibrium would be allocations and prices such that ho
 
   ```{math}
   :label: EqStnrzMarkClrBQ
-    \hat{BQ}_{t} = \left(\frac{1+r_{hh,t}}{1 + \tilde{g}_{n,t}}\right)\left(\sum_{s=E+2}^{E+S+1}\sum_{j=1}^J\rho_{s-1}\lambda_j\hat{\omega}_{s-1,t-1}\hat{b}_{j,s,t}\right) \quad\forall t
+    \hat{BQ}_{t} = \left(\frac{1+r_{p,t}}{1 + \tilde{g}_{n,t}}\right)\left(\sum_{s=E+2}^{E+S+1}\sum_{j=1}^J\rho_{s-1}\lambda_j\hat{\omega}_{s-1,t-1}\hat{b}_{j,s,t}\right) \quad\forall t
   ```

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - openpyxl
 - sphinx>=3.5.4
 - sphinx-book-theme>=0.1.3
+- sphinx-jupyterbook-latex>=0.4.2
 - pip
 - pytest>=6.0
 - pytest-pep8
@@ -27,4 +28,4 @@ dependencies:
 - requests
 - xlwt
 - pip:
-  - jupyter-book>=0.9.1
+  - jupyter-book>=0.11.3

--- a/environment.yml
+++ b/environment.yml
@@ -29,3 +29,4 @@ dependencies:
 - xlwt
 - pip:
   - jupyter-book>=0.11.3
+  - sphinxcontrib-bibtex>=2.0.0

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -131,7 +131,7 @@ def inner_loop(outer_loop_vars, p, client):
             * nssmat (Numpy array): labor supply, size = SxJ
             * new_r (scalar): real interest rate on firm capital
             * new_r_gov (scalar): real interest rate on government debt
-            * new_r_hh (scalar): real interest rate on household
+            * new_r_p (scalar): real interest rate on household
                 portfolio
             * new_w (scalar): real wage rate
             * new_TR (scalar): lump sum transfer amount
@@ -146,7 +146,7 @@ def inner_loop(outer_loop_vars, p, client):
     # unpack variables to pass to function
     if p.budget_balance:
         bssmat, nssmat, r, BQ, TR, factor = outer_loop_vars
-        r_hh = r
+        r_p = r
         Y = 1.0  # placeholder
         K = 1.0  # placeholder
     else:
@@ -159,7 +159,7 @@ def inner_loop(outer_loop_vars, p, client):
     r_gov = fiscal.get_r_gov(r, p)
     D, D_d, D_f, new_borrowing, debt_service, new_borrowing_f =\
         fiscal.get_D_ss(r_gov, Y, p)
-    r_hh = aggr.get_r_hh(r, r_gov, K, D)
+    r_p = aggr.get_r_p(r, r_gov, K, D)
     bq = household.get_bq(BQ, None, p, 'SS')
     tr = household.get_tr(TR, None, p, 'SS')
     ubi = p.ubi_nom_array[-1, :, :] / factor
@@ -167,7 +167,7 @@ def inner_loop(outer_loop_vars, p, client):
     lazy_values = []
     for j in range(p.J):
         guesses = np.append(bssmat[:, j], nssmat[:, j])
-        euler_params = (r_hh, w, bq[:, j], tr[:, j], ubi[:, j], factor, j, p)
+        euler_params = (r_p, w, bq[:, j], tr[:, j], ubi[:, j], factor, j, p)
         lazy_values.append(delayed(opt.fsolve)(euler_equation_solver,
                                                guesses * .9,
                                                args=euler_params,
@@ -202,15 +202,15 @@ def inner_loop(outer_loop_vars, p, client):
     b_s = np.array(list(np.zeros(p.J).reshape(1, p.J)) +
                    list(bssmat[:-1, :]))
     new_r_gov = fiscal.get_r_gov(new_r, p)
-    new_r_hh = aggr.get_r_hh(new_r, new_r_gov, K, D)
-    average_income_model = ((new_r_hh * b_s + new_w * p.e * nssmat) *
+    new_r_p = aggr.get_r_p(new_r, new_r_gov, K, D)
+    average_income_model = ((new_r_p * b_s + new_w * p.e * nssmat) *
                             p.omega_SS.reshape(p.S, 1) *
                             p.lambdas.reshape(1, p.J)).sum()
     if p.baseline:
         new_factor = p.mean_income_data / average_income_model
     else:
         new_factor = factor
-    new_BQ = aggr.get_BQ(new_r_hh, bssmat, None, p, 'SS', False)
+    new_BQ = aggr.get_BQ(new_r_p, bssmat, None, p, 'SS', False)
     new_bq = household.get_bq(new_BQ, None, p, 'SS')
     tr = household.get_tr(TR, None, p, 'SS')
     theta = tax.replacement_rate_vals(nssmat, new_w, new_factor, None, p)
@@ -218,20 +218,20 @@ def inner_loop(outer_loop_vars, p, client):
         np.reshape(p.etr_params[-1, :, :],
                    (p.S, 1, p.etr_params.shape[2])), (1, p.J, 1))
     taxss = tax.net_taxes(
-        new_r_hh, new_w, b_s, nssmat, new_bq, factor, tr, ubi, theta, None,
+        new_r_p, new_w, b_s, nssmat, new_bq, factor, tr, ubi, theta, None,
         None, False, 'SS', p.e, etr_params_3D, p)
     cssmat = household.get_cons(
-        new_r_hh, new_w, b_s, bssmat, nssmat, new_bq, taxss, p.e,
+        new_r_p, new_w, b_s, bssmat, nssmat, new_bq, taxss, p.e,
         p.tau_c[-1, :, :], p)
     total_tax_revenue, _, agg_pension_outlays, UBI_outlays, _, _, _, _, _, _ =\
-        aggr.revenue(new_r_hh, new_w, b_s, nssmat, new_bq, cssmat, Y, L,
+        aggr.revenue(new_r_p, new_w, b_s, nssmat, new_bq, cssmat, Y, L,
                      K, factor, ubi, theta, etr_params_3D, p, 'SS')
     G = fiscal.get_G_ss(Y, total_tax_revenue, agg_pension_outlays, TR,
                         UBI_outlays, new_borrowing, debt_service, p)
     new_TR = fiscal.get_TR(Y, TR, G, total_tax_revenue, agg_pension_outlays,
                            UBI_outlays, p, 'SS')
 
-    return euler_errors, bssmat, nssmat, new_r, new_r_gov, new_r_hh, \
+    return euler_errors, bssmat, nssmat, new_r, new_r_gov, new_r_p, \
         new_w, new_TR, Y, new_factor, new_BQ, average_income_model
 
 
@@ -272,7 +272,7 @@ def SS_solver(bmat, nmat, r, BQ, TR, factor, Y, p, client,
         else:
             outer_loop_vars = (bmat, nmat, r, BQ, Y, TR, factor)
 
-        (euler_errors, new_bmat, new_nmat, new_r, new_r_gov, new_r_hh,
+        (euler_errors, new_bmat, new_nmat, new_r, new_r_gov, new_r_p,
          new_w, new_TR, new_Y, new_factor, new_BQ,
          average_income_model) =\
             inner_loop(outer_loop_vars, p, client)
@@ -329,7 +329,7 @@ def SS_solver(bmat, nmat, r, BQ, TR, factor, Y, p, client,
     Kss, K_d_ss, K_f_ss = aggr.get_K_splits(
         Bss, K_demand_open_ss, D_d_ss, p.zeta_K[-1])
     Yss = firm.get_Y(Kss, Lss, p, 'SS')
-    r_hh_ss = aggr.get_r_hh(rss, r_gov_ss, Kss, Dss)
+    r_p_ss = aggr.get_r_p(rss, r_gov_ss, Kss, Dss)
     # Note that implicity in this computation is that immigrants'
     # wealth is all in the form of private capital
     I_d_ss = aggr.get_I(bssmat_splus1, K_d_ss, K_d_ss, p, 'SS')
@@ -351,28 +351,28 @@ def SS_solver(bmat, nmat, r, BQ, TR, factor, Y, p, client,
     mtry_params_3D = np.tile(np.reshape(
         p.mtry_params[-1, :, :], (p.S, 1, p.mtry_params.shape[2])),
                              (1, p.J, 1))
-    mtry_ss = tax.MTR_income(r_hh_ss, wss, bssmat_s, nssmat, factor, True,
+    mtry_ss = tax.MTR_income(r_p_ss, wss, bssmat_s, nssmat, factor, True,
                              p.e, etr_params_3D, mtry_params_3D, p)
-    mtrx_ss = tax.MTR_income(r_hh_ss, wss, bssmat_s, nssmat, factor, False,
+    mtrx_ss = tax.MTR_income(r_p_ss, wss, bssmat_s, nssmat, factor, False,
                              p.e, etr_params_3D, mtrx_params_3D, p)
-    etr_ss = tax.ETR_income(r_hh_ss, wss, bssmat_s, nssmat, factor, p.e,
+    etr_ss = tax.ETR_income(r_p_ss, wss, bssmat_s, nssmat, factor, p.e,
                             etr_params_3D, p)
 
-    taxss = tax.net_taxes(r_hh_ss, wss, bssmat_s, nssmat, bqssmat,
+    taxss = tax.net_taxes(r_p_ss, wss, bssmat_s, nssmat, bqssmat,
                           factor_ss, trssmat, ubissmat, theta, None, None,
                           False, 'SS', p.e, etr_params_3D, p)
-    cssmat = household.get_cons(r_hh_ss, wss, bssmat_s, bssmat_splus1,
+    cssmat = household.get_cons(r_p_ss, wss, bssmat_s, bssmat_splus1,
                                 nssmat, bqssmat, taxss,
                                 p.e, p.tau_c[-1, :, :], p)
     yss_before_tax_mat = household.get_y(
-        r_hh_ss, wss, bssmat_s, nssmat, p)
+        r_p_ss, wss, bssmat_s, nssmat, p)
     Css = aggr.get_C(cssmat, p, 'SS')
 
     (total_tax_revenue, iit_payroll_tax_revenue, agg_pension_outlays,
      UBI_outlays, bequest_tax_revenue, wealth_tax_revenue, cons_tax_revenue,
      business_tax_revenue, payroll_tax_revenue, iit_revenue
      ) = aggr.revenue(
-         r_hh_ss, wss, bssmat_s, nssmat, bqssmat, cssmat, Yss, Lss, Kss,
+         r_p_ss, wss, bssmat_s, nssmat, bqssmat, cssmat, Yss, Lss, Kss,
          factor, ubissmat, theta, etr_params_3D, p, 'SS')
     Gss = fiscal.get_G_ss(
         Yss, total_tax_revenue, agg_pension_outlays, TR_ss, UBI_outlays,
@@ -383,10 +383,10 @@ def SS_solver(bmat, nmat, r, BQ, TR, factor, Y, p, client,
 
     # solve resource constraint
     # net foreign borrowing
-    debt_service_f = fiscal.get_debt_service_f(r_hh_ss, D_f_ss)
+    debt_service_f = fiscal.get_debt_service_f(r_p_ss, D_f_ss)
     RC = aggr.resource_constraint(
         Yss, Css, Gss, I_d_ss, K_f_ss, new_borrowing_f, debt_service_f,
-        r_hh_ss, p)
+        r_p_ss, p)
     if VERBOSE:
         print('Foreign debt holdings = ', D_f_ss)
         print('Foreign capital holdings = ', K_f_ss)
@@ -420,7 +420,7 @@ def SS_solver(bmat, nmat, r, BQ, TR, factor, Y, p, client,
               'Yss': Yss, 'Dss': Dss, 'D_f_ss': D_f_ss,
               'D_d_ss': D_d_ss, 'wss': wss, 'rss': rss,
               'total_taxes_ss': taxss, 'ubissmat': ubissmat,
-              'r_gov_ss': r_gov_ss, 'r_hh_ss': r_hh_ss, 'theta': theta,
+              'r_gov_ss': r_gov_ss, 'r_p_ss': r_p_ss, 'theta': theta,
               'BQss': BQss, 'factor_ss': factor_ss, 'bssmat_s': bssmat_s,
               'cssmat': cssmat, 'bssmat_splus1': bssmat_splus1,
               'yss_before_tax_mat': yss_before_tax_mat,
@@ -502,7 +502,7 @@ def SS_fsolve(guesses, *args):
 
     # Solve for the steady state levels of b and n, given w, r, TR and
     # factor
-    (euler_errors, bssmat, nssmat, new_r, new_r_gov, new_r_hh, new_w,
+    (euler_errors, bssmat, nssmat, new_r, new_r_gov, new_r_p, new_w,
      new_TR, new_Y, new_factor, new_BQ, average_income_model) =\
         inner_loop(outer_loop_vars, p, client)
 

--- a/ogcore/aggregates.py
+++ b/ogcore/aggregates.py
@@ -331,13 +331,13 @@ def revenue(r, w, b, n, bq, c, Y, L, K, factor, ubi, theta, etr_params,
             payroll_tax_revenue, iit_revenue)
 
 
-def get_r_hh(r, r_gov, K, D):
+def get_r_p(r, r_gov, K, D):
     r'''
     Compute the interest rate on the household's portfolio of assets,
     a mix of government debt and private equity.
 
     .. math::
-        r_{hh,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}}
+        r_{p,t} = \frac{r_{gov,t}D_{t} + r_{t}K_{t}}{D_{t} + K_{t}}
 
     Args:
         r (array_like): the real interest rate
@@ -346,13 +346,13 @@ def get_r_hh(r, r_gov, K, D):
         D (array_like): aggregate government debt
 
     Returns:
-        r_hh (array_like): the real interest rate on the households
+        r_p (array_like): the real interest rate on the households
             portfolio
 
     '''
-    r_hh = ((r * K) + (r_gov * D)) / (K + D)
+    r_p = ((r * K) + (r_gov * D)) / (K + D)
 
-    return r_hh
+    return r_p
 
 
 def resource_constraint(Y, C, G, I, K_f, new_borrowing_f,
@@ -363,9 +363,9 @@ def resource_constraint(Y, C, G, I, K_f, new_borrowing_f,
     .. math::
         \hat{Y}_{t} = \hat{C}_{t} + (\hat{K}^{d}_{t+1}e^{g_{y}}
         (1+g_{n,t+1}) - \hat{K}^{d}_{t}) + \delta \hat{K}_{t} +
-        \hat{G}_{t} + r_{hh, t}\hat{K}^{f}_{t} -
+        \hat{G}_{t} + r_{p, t}\hat{K}^{f}_{t} -
         (\hat{D}^{f}_{t+1}e^{g_{y}}(1+g_{n,t+1})- \hat{D}^{f}_{t}) +
-        r_{hh,t}\hat{D}^{f}_{t}
+        r_{p,t}\hat{D}^{f}_{t}
 
     Args:
         Y (array_like): aggregate output

--- a/ogcore/constants.py
+++ b/ogcore/constants.py
@@ -20,7 +20,7 @@ VAR_LABELS = {'Y': 'GDP ($Y_t$)', 'C': 'Consumption ($C_t$)',
               'D_f': 'Foreign-owned Gov Debt ($D^f_t$)',
               'r': 'Real interest rate ($r_t$)',
               'r_gov': 'Real interest rate on gov debt ($r_{gov,t}$)',
-              'r_hh': 'Real interest rate on HH portfolio ($r_{hh,t}$)',
+              'r_p': 'Real interest rate on HH portfolio ($r_{p,t}$)',
               'w': 'Wage rate', 'BQ': 'Aggregate bequests ($BQ_{j,t}$)',
               'total_tax_revenue': 'Total tax revenue ($REV_t$)',
               'business_tax_revenue': 'Business tax revenue',
@@ -73,7 +73,7 @@ VAR_LABELS = {'Y': 'GDP ($Y_t$)', 'C': 'Consumption ($C_t$)',
               'rss': 'Real interest rate ($\\bar{r}$)',
               'r_gov_ss':
                   'Real interest rate on gov debt ($\\bar{r}_{gov}$)',
-              'r_hh_ss':
+              'r_p_ss':
                   'Real interest rate on HH portfolio ($\\bar{r}_{hh}$)',
               'wss': 'Wage rate ($\\bar{w}$)',
               'BQss': 'Aggregate bequests ($\\bar{BQ}_{j}$)',

--- a/ogcore/fiscal.py
+++ b/ogcore/fiscal.py
@@ -217,12 +217,12 @@ def get_G_ss(Y, total_tax_revenue, agg_pension_outlays, TR, UBI_outlays,
     return G
 
 
-def get_debt_service_f(r_hh, D_f):
+def get_debt_service_f(r_p, D_f):
     r'''
     Function to compute foreign debt service payments.
 
     .. math::
-        \text{Foreign debt service}_{t} = r_{hh,t} * D^{f}_{t}
+        \text{Foreign debt service}_{t} = r_{p,t} * D^{f}_{t}
 
     Args:
 
@@ -230,7 +230,7 @@ def get_debt_service_f(r_hh, D_f):
         debt_service_f (array_like): foreign debt service payment amount
 
     '''
-    debt_service_f = r_hh * D_f
+    debt_service_f = r_p * D_f
 
     return debt_service_f
 

--- a/ogcore/household.py
+++ b/ogcore/household.py
@@ -387,22 +387,22 @@ def FOC_labor(r, w, b, b_splus1, n, bq, factor, tr, ubi, theta, chi_n, e,
     return FOC_error
 
 
-def get_y(r_hh, w, b_s, n, p):
+def get_y(r_p, w, b_s, n, p):
     '''
     Compute household income before taxes.
 
     ..math::
-        y_{j,s,t} = r_{hh,t}b_{j,s,t} + w_{t}e_{j,s}n_{j,s,t}
+        y_{j,s,t} = r_{p,t}b_{j,s,t} + w_{t}e_{j,s}n_{j,s,t}
 
     Args:
-        r_hh (array_like): real interest rate on the household portfolio
+        r_p (array_like): real interest rate on the household portfolio
         w (array_like): real wage rate
         b_s (Numpy array): household savings coming into the period
         n (Numpy array): household labor supply
         p (OG-Core Specifications object): model parameters
     '''
 
-    y = r_hh * b_s + w * p.e * n
+    y = r_p * b_s + w * p.e * n
 
     return y
 

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -63,7 +63,7 @@ def plot_aggregates(base_tpi, base_params, reform_tpi=None,
     fig1, ax1 = plt.subplots()
     for i, v in enumerate(var_list):
         if plot_type == 'pct_diff':
-            if v in ['r_gov', 'r', 'r_hh']:
+            if v in ['r_gov', 'r', 'r_p']:
                 # Compute just percentage point changes for rates
                 plot_var = reform_tpi[v] - base_tpi[v]
             else:

--- a/ogcore/output_tables.py
+++ b/ogcore/output_tables.py
@@ -373,7 +373,7 @@ def tp_output_dump_table(base_params, base_tpi, reform_params=None,
     T = base_params.T
     # keep just items of interest for final table
     vars_to_keep = ['Y', 'L', 'G', 'TR', 'B', 'K', 'K_d', 'K_f', 'D',
-                    'D_d', 'D_f', 'r', 'r_gov', 'r_hh', 'w',
+                    'D_d', 'D_f', 'r', 'r_gov', 'r_p', 'w',
                     'total_tax_revenue', 'business_tax_revenue']
     base_dict = {k: base_tpi[k] for k in vars_to_keep}
     # update key names
@@ -491,25 +491,25 @@ def dynamic_revenue_decomposition(
     indiv_liab = {}
     # Baseline IIT + payroll tax liability
     indiv_liab['A'] = tax.income_tax_liab(
-        base_tpi['r_hh'][:T], base_tpi['w'][:T], base_tpi['bmat_s'],
+        base_tpi['r_p'][:T], base_tpi['w'][:T], base_tpi['bmat_s'],
         base_tpi['n_mat'][:T, :, :], base_ss['factor_ss'], 0, None,
         'TPI', base_params.e, base_etr_params_4D, base_params)
     # IIT + payroll tax liability using baseline behavior and macros
     # with the reform tax functions (this is the OG-Core static estimate)
     indiv_liab['B'] = tax.income_tax_liab(
-        base_tpi['r_hh'][:T], base_tpi['w'][:T], base_tpi['bmat_s'],
+        base_tpi['r_p'][:T], base_tpi['w'][:T], base_tpi['bmat_s'],
         base_tpi['n_mat'][:T, :, :], base_ss['factor_ss'], 0, None,
         'TPI', base_params.e, reform_etr_params_4D, base_params)
     # IIT + payroll tax liability using reform behavior and baseline
     # macros
     indiv_liab['C'] = tax.income_tax_liab(
-        base_tpi['r_hh'][:T], base_tpi['w'][:T],
+        base_tpi['r_p'][:T], base_tpi['w'][:T],
         reform_tpi['bmat_s'], reform_tpi['n_mat'][:T, :, :],
         base_ss['factor_ss'], 0, None, 'TPI', reform_params.e,
         reform_etr_params_4D, reform_params)
     # IIT + payroll tax liability from the reform simulation
     indiv_liab['D'] = tax.income_tax_liab(
-        reform_tpi['r_hh'][:T], reform_tpi['w'][:T],
+        reform_tpi['r_p'][:T], reform_tpi['w'][:T],
         reform_tpi['bmat_s'], reform_tpi['n_mat'][:T, :, :],
         base_ss['factor_ss'], 0, None, 'TPI', reform_params.e,
         reform_etr_params_4D, reform_params)

--- a/ogcore/tests/test_SS.py
+++ b/ogcore/tests/test_SS.py
@@ -164,6 +164,7 @@ def test_SS_solver(baseline, param_updates, filename, dask_client):
                              factorguess, Yguess, p, dask_client, False)
     expected_dict = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', filename))
+    expected_dict['r_p_ss'] = expected_dict.pop('r_hh_ss')
 
     for k, v in expected_dict.items():
         print('Testing ', k)
@@ -205,6 +206,7 @@ def test_SS_solver_extra(baseline, param_updates, filename, dask_client):
                              factorguess, Yguess, p, dask_client, False)
     expected_dict = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', filename))
+    expected_dict['r_p_ss'] = expected_dict.pop('r_hh_ss')
 
     for k, v in expected_dict.items():
         print('Testing ', k)
@@ -490,6 +492,7 @@ def test_run_SS(baseline, param_updates, filename, dask_client):
     test_dict = SS.run_SS(p, client=dask_client)
     expected_dict = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', filename))
+    expected_dict['r_p_ss'] = expected_dict.pop('r_hh_ss')
 
     for k, v in expected_dict.items():
         print('Checking item = ', k)

--- a/ogcore/tests/test_TPI.py
+++ b/ogcore/tests/test_TPI.py
@@ -212,6 +212,7 @@ def test_run_TPI_full_run(baseline, param_updates, filename, tmp_path,
 
     test_dict = TPI.run_TPI(p, client=dask_client)
     expected_dict = utils.safe_read_pickle(filename)
+    expected_dict['r_p'] = expected_dict.pop('r_hh')
 
     for k, v in expected_dict.items():
         try:
@@ -275,6 +276,7 @@ def test_run_TPI(baseline, param_updates, filename, tmp_path,
     TPI.ENFORCE_SOLUTION_CHECKS = False
     test_dict = TPI.run_TPI(p, client=dask_client)
     expected_dict = utils.safe_read_pickle(filename)
+    expected_dict['r_p'] = expected_dict.pop('r_hh')
 
     for k, v in expected_dict.items():
         print('Max diff in ', k, ' = ')
@@ -354,6 +356,7 @@ def test_run_TPI_extra(baseline, param_updates, filename, tmp_path,
     TPI.ENFORCE_SOLUTION_CHECKS = False
     test_dict = TPI.run_TPI(p, client=dask_client)
     expected_dict = utils.safe_read_pickle(filename)
+    expected_dict['r_p'] = expected_dict.pop('r_hh')
 
     for k, v in expected_dict.items():
         try:

--- a/ogcore/tests/test_aggregates.py
+++ b/ogcore/tests/test_aggregates.py
@@ -431,13 +431,13 @@ test_data = [(0.04, 0.02, 2.0, 4.0, 0.026666667),
 
 @pytest.mark.parametrize('r,r_gov,B,D,expected', test_data,
                          ids=['scalar', 'vector', 'no debt'])
-def test_get_r_hh(r, r_gov, B, D, expected):
+def test_get_r_p(r, r_gov, B, D, expected):
     """
     Test function to compute interet rate on household portfolio.
     """
-    r_hh_test = aggr.get_r_hh(r, r_gov, B, D)
+    r_p_test = aggr.get_r_p(r, r_gov, B, D)
 
-    assert(np.allclose(r_hh_test, expected))
+    assert(np.allclose(r_p_test, expected))
 
 
 def test_resource_constraint():

--- a/ogcore/tests/test_household.py
+++ b/ogcore/tests/test_household.py
@@ -581,7 +581,7 @@ def test_get_y():
     '''
     Test of household.get_y() function.
     '''
-    r_hh = np.array([0.05, 0.04, 0.09])
+    r_p = np.array([0.05, 0.04, 0.09])
     w = np.array([1.2, 0.8, 2.5])
     b_s = np.array([0.5, 0.99, 9])
     n = np.array([0.8, 3.2, 0.2])
@@ -591,7 +591,7 @@ def test_get_y():
     p.S = 3
     p.e = np.array([0.99, 1.5, 0.2])
 
-    test_y = household.get_y(r_hh, w, b_s, n, p)
+    test_y = household.get_y(r_p, w, b_s, n, p)
 
     assert np.allclose(test_y, expected_y)
 

--- a/ogcore/tests/test_output_plots.py
+++ b/ogcore/tests/test_output_plots.py
@@ -13,16 +13,18 @@ from ogcore import utils, output_plots
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 base_ss = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'SS_vars_baseline.pkl'))
+base_ss['r_p_ss'] = base_ss.pop('r_hh_ss')
 base_tpi = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'TPI_vars_baseline.pkl'))
+base_tpi['r_p'] = base_tpi.pop('r_hh')
 base_params = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'model_params_baseline.pkl'))
-base_taxfunctions = utils.safe_read_pickle(
-    os.path.join(CUR_PATH, 'test_io_data', 'TxFuncEst_baseline.pkl'))
 reform_ss = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'SS_vars_reform.pkl'))
+reform_ss['r_p_ss'] = reform_ss.pop('r_hh_ss')
 reform_tpi = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'TPI_vars_reform.pkl'))
+reform_tpi['r_p'] = reform_tpi.pop('r_hh')
 reform_params = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'model_params_reform.pkl'))
 reform_taxfunctions = utils.safe_read_pickle(

--- a/ogcore/tests/test_output_tables.py
+++ b/ogcore/tests/test_output_tables.py
@@ -12,14 +12,18 @@ from ogcore import utils, output_tables
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 base_ss = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'SS_vars_baseline.pkl'))
+base_ss['r_p_ss'] = base_ss.pop('r_hh_ss')
 base_tpi = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'TPI_vars_baseline.pkl'))
+base_tpi['r_p'] = base_tpi.pop('r_hh')
 base_params = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'model_params_baseline.pkl'))
 reform_ss = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'SS_vars_reform.pkl'))
+reform_ss['r_p_ss'] = reform_ss.pop('r_hh_ss')
 reform_tpi = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'TPI_vars_reform.pkl'))
+reform_tpi['r_p'] = reform_tpi.pop('r_hh')
 reform_params = utils.safe_read_pickle(
     os.path.join(CUR_PATH, 'test_io_data', 'model_params_reform.pkl'))
 


### PR DESCRIPTION
This PR changes how one thinks about how domestic and foreign savings are held.  It introduces a financial intermediary into the model. This intermediary then rationalizes the return to the portfolio of government debt held by domestic and foreign investors.  

The changes in this PR do not alter any of the equations underlying the model or its solution, only their interpretation.

All references to `r_hh` in the theory and code have been changed to `r_p` to better denote the return to the portfolio of investments held by the financial intermediary.  This return is realized not just by domestic households, but also foreign investors in domestic assets.