### PR TITLE
Updated generic version in intro.md

### DIFF
--- a/docs/book/content/intro/intro.md
+++ b/docs/book/content/intro/intro.md
@@ -27,4 +27,4 @@ The model is continuously under development. Users will be notified through [clo
 (Sec_CitingOGUSA)=
 ## Citing OG-Core
 
-`OG-Core` (Version 0.6.4)[Source code], https://github.com/PSLmodels/OG-Core
+`OG-Core` (Version #.#.#)[Source code], https://github.com/PSLmodels/OG-Core


### PR DESCRIPTION
@jdebacker. This PR updates the OG-Core version number at the bottom of the `intro.md` documentation, which currently refers to a particular version number. This PR changes that version number to a generic `#.#.#` so we don't have to remember to update that part of the documentation every time we update the version and so that the version number in the documentation doesn't fall out of date if we forget to update it. This is what is done in the [`Tax-Calculator` documentation intro page](https://taxcalc.pslmodels.org/#citing-tax-calculator).