### PR TITLE
change around how style file used

### DIFF
--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -7,10 +7,6 @@ from ogcore.constants import (GROUP_LABELS, VAR_LABELS, ToGDP_LABELS,
                               CBO_UNITS, DEFAULT_START_YEAR)
 import ogcore.utils as utils
 from ogcore.utils import Inequality
-style_file = os.path.join(
-    'https://github.com/PSLmodels/OG-Core/blob/master/ogcore/' +
-    'OGcorePlots.mplstyle')
-plt.style.use(style_file)
 
 
 def plot_aggregates(base_tpi, base_params, reform_tpi=None,

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -6,10 +6,6 @@ import matplotlib
 from ogcore.constants import GROUP_LABELS
 from ogcore import utils, txfunc
 from ogcore.constants import DEFAULT_START_YEAR, VAR_LABELS
-style_file = os.path.join(
-    'https://github.com/PSLmodels/OG-Core/blob/master/ogcore/' +
-    'OGcorePlots.mplstyle')
-plt.style.use(style_file)
 
 
 def plot_imm_rates(p, year=DEFAULT_START_YEAR, include_title=False,

--- a/run_examples/run_ogcore_example.py
+++ b/run_examples/run_ogcore_example.py
@@ -14,6 +14,9 @@ from ogcore.execute import runner
 from ogcore.parameters import Specifications
 from ogcore.constants import REFORM_DIR, BASELINE_DIR
 from ogcore.utils import safe_read_pickle
+import matplotlib.pyplot as plt
+style_file = os.path.join('..', 'ogcore', 'OGcorePlots.mplstyle')
+plt.style.use(style_file)
 
 
 def main():


### PR DESCRIPTION
This PR should remedy issues users of country specific models are having when they try to import the `ogcore` plotting functions.   The issue has to do with not being able find the style file when `ogcore` is installed only as a package.