### PR TITLE
Updated mpl style file to url reference in run_ogcore_example.py

### DIFF
--- a/run_examples/run_ogcore_example.py
+++ b/run_examples/run_ogcore_example.py
@@ -15,8 +15,9 @@ from ogcore.parameters import Specifications
 from ogcore.constants import REFORM_DIR, BASELINE_DIR
 from ogcore.utils import safe_read_pickle
 import matplotlib.pyplot as plt
-style_file = os.path.join('..', 'ogcore', 'OGcorePlots.mplstyle')
-plt.style.use(style_file)
+style_file_url = ('https://raw.githubusercontent.com/PSLmodels/OG-Core/' +
+                  'master/ogcore/OGcorePlots.mplstyle')
+plt.style.use(style_file_url)
 
 
 def main():


### PR DESCRIPTION
This PR changes the Matplotlib style file reference in what was lines 18-19 of [`run_ogcore_example.py`](https://github.com/PSLmodels/OG-Core/blob/master/run_examples/run_ogcore_example.py) from a relative path reference to a URL. This solves two related problems I was having.

1. When I would try to run the [`run_ogcore_example.py`](https://github.com/PSLmodels/OG-Core/blob/master/run_examples/run_ogcore_example.py) script on my local machine from any directory other than `OG-Core/run_examples/`, I would get the following traceback error, saying it could not find the `.mplstyle` file referenced in line 19 of `run_ogcore_example.py`.
```
Traceback (most recent call last):
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/site-packages/matplotlib/style/core.py", line 127, in use
    rc = rc_params_from_file(style, use_default_template=False)
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/site-packages/matplotlib/__init__.py", line 852, in rc_params_from_file
    config_from_file = _rc_params_in_file(fname, fail_on_error=fail_on_error)
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/site-packages/matplotlib/__init__.py", line 778, in _rc_params_in_file
    with _open_file_or_url(fname) as fd:
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/site-packages/matplotlib/__init__.py", line 755, in _open_file_or_url
    with open(fname, encoding=encoding) as f:
FileNotFoundError: [Errno 2] No such file or directory: '../ogcore/OGcorePlots.mplstyle'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/richardevans/Documents/Economics/OSE/OG-Core/ogcore/tests/test_run_example.py", line 23, in call_run_ogcore_example
    spec.loader.exec_module(roe_module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/richardevans/Documents/Economics/OSE/OG-Core/run_examples/run_ogcore_example.py", line 19, in <module>
    plt.style.use(style_file)
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/site-packages/matplotlib/style/core.py", line 130, in use
    raise IOError(
OSError: '../ogcore/OGcorePlots.mplstyle' not found in the style library and input is not a valid URL or path; see `style.available` for list of available styles
```

2. I would get a test failure resulting from the same traceback error whenever I ran the [`test_run_example.py`](https://github.com/PSLmodels/OG-Core/blob/master/ogcore/tests/test_run_example.py) test locally on my machine from any directory other than `./ogcore/`.

The problem in both cases is that the relative path in line 19 of [`run_ogcore_example.py`](https://github.com/PSLmodels/OG-Core/blob/master/run_examples/run_ogcore_example.py)  requires one to be in a certain directory for the path to be located. The URL solves this issue. I can run the example script successfully from any directory in my repo, and the test passes from any directory in my repo.

cc: @jdebacker 