### PR TITLE
Add auto-publish to PyPI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,4 +49,3 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
-

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,3 +36,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/book/_build/html # The folder the action should deploy.
+  publish:
+    needs: build
+    name: Publish to PyPI
+    if: github.repository == 'PSLmodels/OG-Core'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Build package
+        run: make pip-package
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}
+          skip_existing: true

--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,7 @@ git-sync:
 .PHONY=git-pr
 git-pr:
 	@./gitpr $(N)
+
+pip-package:
+	pip install wheel
+	python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,16 @@ except ImportError:
 with open('README.md') as f:
     longdesc = f.read()
 
-version = '0.7.0'
+version = '0.8.0'
 
 config = {
-    'description': 'General equilibribum, overlapping generations model for the USA',
+    'description': 'A general equilibribum overlapping generations model for fiscal policy analysis',
+    'long_description_content_type': 'text/markdown',
     'long_description': longdesc,
     'url': 'https://github.com/PSLmodels/OG-Core/',
     'download_url': 'https://github.com/PLSmodels/OG-Core/',
     'version': version,
-    'license': 'CC0 1.0 Universal public domain dedication',
+    'license': 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
     'packages': ['ogcore'],
     'include_package_data': True,
     'name': 'ogcore',
@@ -33,7 +34,7 @@ config = {
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        'License :: OSI Approved :: CC0 1.0 Universal public domain dedication',
+        'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Following up on a call recently where there were some issues with pip installing, I thought I'd just file a PR here if it's useful. This is basically Jason's PR but with the extra step of an auto-publish action on the master branch. I think the only thing needed would be to make sure PSLmodels has an organisation secret called `PYPI` which is a token exported from the `pypi.org` account.

@jdebacker @rickecon @jpycroft FYI