### PR TITLE
Move PyPI publish to separate action

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,23 +36,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/book/_build/html # The folder the action should deploy.
-  publish:
-    needs: build
-    name: Publish to PyPI
-    if: github.repository == 'PSLmodels/OG-Core'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Build package
-        run: make pip-package
-      - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI }}
-          skip_existing: true

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,27 @@
+name: Publish package to PyPI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Publish to PyPI
+    if: github.repository == 'PSLmodels/OG-Core'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Build package
+        run: make pip-package
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}
+          skip_existing: true


### PR DESCRIPTION
This PR moves the publishing of the `ogcore` package to PyPI into a separate GH Action workflow yaml. This makes it more clear what action is failing. It also should fix an issue with the prior flow, which was relying on an action that didn't exist in that yaml.