### PR TITLE
Update test_run_example.py

### DIFF
--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -16,7 +16,7 @@ import pytest
 def call_run_ogcore_example():
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     path = Path(cur_path)
-    roe_fldr = os.path.join(path.parent.parent, "run_examples")
+    roe_fldr = os.path.join(path.parent, "run_examples")
     roe_file_path = os.path.join(roe_fldr, "run_ogcore_example.py")
     spec = importlib.util.spec_from_file_location(
         'run_ogcore_example.py', roe_file_path)
@@ -43,7 +43,7 @@ def test_run_ogcore_example(f=call_run_ogcore_example):
     # Delete directory created by run_ogcore_example.py
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     path = Path(cur_path)
-    roe_output_dir = os.path.join(path.parent.parent, "run_examples",
+    roe_output_dir = os.path.join(path.parent, "run_examples",
                                   "OUTPUT_BASELINE")
     shutil.rmtree(roe_output_dir)
 
@@ -59,13 +59,13 @@ def test_run_ogcore_example_output(f=call_run_ogcore_example):
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     path = Path(cur_path)
     expected_df = pd.read_csv(os.path.join(
-        path.parent.parent, "run_examples",
+        path.parent, "run_examples",
         "expected_ogcore_example_output.csv"))
     # read in output from this run
     test_df = pd.read_csv(os.path.join(
-        path.parent.parent, "run_examples", "ogcore_example_output.csv"))
+        path.parent, "run_examples", "ogcore_example_output.csv"))
     # Delete directory created by run_ogcore_example.py
-    roe_output_dir = os.path.join(path.parent.parent, "run_examples",
+    roe_output_dir = os.path.join(path.parent, "run_examples",
                                   "OUTPUT_BASELINE")
     shutil.rmtree(roe_output_dir)
 


### PR DESCRIPTION
Currently in the master branch if you run the full set of tests (6hrs 44min),
```python
pytest ./tests/
```
you get the following results, with failures of the two `@pytest.mark.local` tests in `test_run_example.py`.
```
tests/test_SS.py ................................                        [  7%]
tests/test_TPI.py ........................                               [ 12%]
tests/test_aggregates.py ................................                [ 20%]
tests/test_basic.py ....                                                 [ 21%]
tests/test_elliptical_u_est.py .......                                   [ 22%]
tests/test_execute.py .                                                  [ 22%]
tests/test_firm.py .......................................               [ 31%]
tests/test_fiscal.py ..................                                  [ 35%]
tests/test_household.py ........................................         [ 45%]
tests/test_output_plots.py ......................................        [ 53%]
tests/test_output_tables.py .............                                [ 56%]
tests/test_parameter_plots.py ...................................        [ 64%]
tests/test_parameter_tables.py .......                                   [ 66%]
tests/test_parameters.py .............                                   [ 69%]
tests/test_run_example.py FF                                             [ 69%]
tests/test_run_ogcore.py .                                               [ 70%]
tests/test_tax.py ...............................                        [ 77%]
tests/test_txfunc.py .........................                           [ 82%]
tests/test_user_inputs.py .........                                      [ 84%]
tests/test_utils.py .................................................... [ 96%]
............                                                             [ 99%]
tests/test_wealth.py ..                                                  [100%]

=========================== short test summary info ============================
FAILED tests/test_run_example.py::test_run_ogcore_example - FileNotFoundError...
FAILED tests/test_run_example.py::test_run_ogcore_example_output - FileNotFou...
=========== 2 failed, 435 passed, 78 warnings in 24281.30s (6:44:41) ===========
=================================== FAILURES ===================================
___________________________ test_run_ogcore_example ____________________________

f = <function call_run_ogcore_example at 0x174e85510>

    @pytest.mark.local
    def test_run_ogcore_example(f=call_run_ogcore_example):
        p = multiprocessing.Process(
            target=f, name="run_ogcore_example", args=())
        p.start()
        time.sleep(300)
        if p.is_alive():
            p.terminate()
            p.join()
            timetest = True
        else:
            print("run_ogcore_example did not run for minimum time")
            timetest = False
        print('timetest ==', timetest)
        # Delete directory created by run_ogcore_example.py
        cur_path = os.path.split(os.path.abspath(__file__))[0]
        path = Path(cur_path)
        roe_output_dir = os.path.join(path.parent.parent, "run_examples",
                                      "OUTPUT_BASELINE")
>       shutil.rmtree(roe_output_dir)

tests/test_run_example.py:48:

E FileNotFoundError: [Errno 2] No such file or directory: '/Users/richardevans/Documents/Economics/OSE/run_examples/OUTPUT_BASELINE'

----------------------------- Captured stdout call -----------------------------
run_ogcore_example did not run for minimum time
timetest == False
----------------------------- Captured stderr call -----------------------------
Process run_ogcore_example:
Traceback (most recent call last):
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/richardevans/Documents/Economics/OSE/OG-Core/tests/test_run_example.py", line 25, in call_run_ogcore_example
    spec.loader.exec_module(roe_module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1016, in get_code
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/Users/richardevans/Documents/Economics/OSE/run_examples/run_ogcore_example.py'

________________________ test_run_ogcore_example_output ________________________

f = <function call_run_ogcore_example at 0x174e85510>

    @pytest.mark.local
    def test_run_ogcore_example_output(f=call_run_ogcore_example):
        p = multiprocessing.Process(
            target=f, name="run_ogcore_example", args=())
        p.start()
        p.join()  # this makes sure process finished running before going on
        cur_path = os.path.split(os.path.abspath(__file__))[0]
        path = Path(cur_path)
>       expected_df = pd.read_csv(os.path.join(
            path.parent.parent, "run_examples",
            "expected_ogcore_example_output.csv"))

tests/test_run_example.py:61:

E FileNotFoundError: [Errno 2] No such file or directory: '/Users/richardevans/Documents/Economics/OSE/run_examples/expected_ogcore_example_output.csv'

----------------------------- Captured stderr call -----------------------------
Process run_ogcore_example:
Traceback (most recent call last):
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/Users/richardevans/opt/anaconda3/envs/ogcore-dev/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/richardevans/Documents/Economics/OSE/OG-Core/tests/test_run_example.py", line 25, in call_run_ogcore_example
    spec.loader.exec_module(roe_module)
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1016, in get_code
  File "<frozen importlib._bootstrap_external>", line 1073, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/Users/richardevans/Documents/Economics/OSE/run_examples/run_ogcore_example.py'
```
The errors are just the relative file paths needing to be adjusted for the new location of the `./tests/` directory. After making this change, the tests run properly.
```
tests/test_run_example.py ..                                                                [100%]

================================= 2 passed in 8602.08s (2:23:22) ==================================
```

cc: @jdebacker 