### PR TITLE
Add pop_base_yr to default_parameters.json

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -3245,6 +3245,25 @@
             }
         }
     },
+    "pop_base_yr": {
+        "title": "Base year of population data to load or download",
+        "description": "Base year of population data to load or download",
+        "section_1": "Demographic Parameters",
+        "notes": "",
+        "type": "int",
+        "number_dims": 1,
+        "value": [
+            {
+                "value": 2018
+            }
+        ],
+        "validators": {
+            "range": {
+                "min": 2012,
+                "max": 2018
+            }
+        }
+    },
     "omega": {
         "title": "Population distribution (fraction at each age) over the time path.",
         "description": "Population distribution (fraction at each age) over the time path.",

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -3251,7 +3251,6 @@
         "section_1": "Demographic Parameters",
         "notes": "",
         "type": "int",
-        "number_dims": 1,
         "value": [
             {
                 "value": 2018


### PR DESCRIPTION
This PR adds a parameter names `pop_base_year` to OG-Core `default_parameters.json`. I am trying to implement this parameter in a PR to the `OG-UK` repository ([PR #36](https://github.com/PSLmodels/OG-UK/pull/36)). This parameter is valuable for the [`OG-UK`](https://github.com/PSLmodels/OG-UK) country calibration repository because the UK demographics from Eurostat come from a base year. We then have to age the current population to the correct `start_year`.

The current settings in this PR of min and max and default values are based on restrictions for `OG-UK`. However, we can adjust those settings to be more general to include `OG-USA` and other country calibration repositories. I think the principle should be that this parameter's bounds in `OG-Core` should have max and min values that cover the maximum range of values available in country calibrations. Then each country calibration repository can place more restrictive settings within its respective `demographics.py` module and corresponding functions. But I think this parameter is general enough to be warranted in the `OG-Core` repo.

For example, we should probably update `OG-USA`'s `demographics.py` module to also use this parameter. I think the current `OG-USA` module hard codes a pretty old year, and treats that at the demographic values of the `start_year`.

cc: @jdebacker 