### PR TITLE
Remove hard coded year in plot of population distribution over the time path

### DIFF
--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -504,11 +504,11 @@ def plot_imm_fixed(
 
 def plot_population_path(
     age_per_EpS,
-    pop_2013_pct,
+    initial_pop_pct,
     omega_path_lev,
     omega_SSfx,
+    data_year,
     curr_year,
-    E,
     S,
     output_dir=None,
 ):
@@ -523,8 +523,8 @@ def plot_population_path(
             over the transition path
         omega_SSfx (Numpy array): number of households by age
             in the SS
+        data_year (int): year of data for initial_pop_pct
         curr_year (int): current year in the model
-        E (int): age at which household becomes economically active
         S (int): number of years which household is economically active
         output_dir (str): path to save figure to, if None then figure
             is returned
@@ -535,7 +535,7 @@ def plot_population_path(
 
     """
     fig, ax = plt.subplots()
-    plt.plot(age_per_EpS, pop_2013_pct, label="2013 pop.")
+    plt.plot(age_per_EpS, initial_pop_pct, label=str(data_year) + " pop.")
     plt.plot(
         age_per_EpS,
         (omega_path_lev[:, 0] / omega_path_lev[:, 0].sum()),

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -298,15 +298,21 @@ def test_plot_imm_fixed_save_fig(tmpdir):
 
 
 def test_plot_population_path():
-    E = 0
     S = base_params.S
     age_per_EpS = np.arange(21, S + 21)
-    pop_2013_pct = base_params.omega[0, :]
+    initial_pop_pct = base_params.omega[0, :]
     omega_path_lev = base_params.omega.T
     omega_SSfx = base_params.omega_SS
+    data_year = base_params.start_year
     curr_year = base_params.start_year
     fig = parameter_plots.plot_population_path(
-        age_per_EpS, pop_2013_pct, omega_path_lev, omega_SSfx, curr_year, E, S
+        age_per_EpS,
+        initial_pop_pct,
+        omega_path_lev,
+        omega_SSfx,
+        data_year,
+        curr_year,
+        S,
     )
     assert fig
 


### PR DESCRIPTION
This PR addresses Issue #823 by removing the hard coded label for the year used for the initial population in the `parameter_plots.plot_population_path()` function.