### PR TITLE
Add mono as tax_func_type option in default_parameters.json

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -3145,7 +3145,8 @@
                     "DEP",
                     "DEP_totalinc",
                     "GS",
-                    "linear"
+                    "linear",
+                    "mono"
                 ]
             }
         }

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -157,7 +157,7 @@ def test_implement_bad_reform2():
     assert len(specs.errors) > 0
     assert specs.errors["tax_func_type"][0] == (
         'tax_func_type "not_a_functional_form" must be in list of '
-        + "choices DEP, DEP_totalinc, GS, linear."
+        + "choices DEP, DEP_totalinc, GS, linear, mono."
     )
 
 


### PR DESCRIPTION
This PR adds the "mono" type in the list of acceptable types in the `tax_func_type` variable in `default_parameters.json`. This was noted as missing in Issue #828.

cc: @jdebacker 