### PR TITLE
Updated Python version restriction <3.11 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogcore-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7
+- python>=3.7.7, <3.11  # This restriction can be removed as soon as we test Python 3.11
 - ipython
 - setuptools
 - mkl>=2021.4.0

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -3145,7 +3145,8 @@
                     "DEP",
                     "DEP_totalinc",
                     "GS",
-                    "linear"
+                    "linear",
+                    "mono"
                 ]
             }
         }

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         ]
     },
     include_packages=True,
-    python_requires=">=3.7.7",
+    python_requires=">=3.7.7, <3.11",
     install_requires=[
         "mkl>=2021.4.0",
         "psutil",

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -157,7 +157,7 @@ def test_implement_bad_reform2():
     assert len(specs.errors) > 0
     assert specs.errors["tax_func_type"][0] == (
         'tax_func_type "not_a_functional_form" must be in list of '
-        + "choices DEP, DEP_totalinc, GS, linear."
+        + "choices DEP, DEP_totalinc, GS, linear, mono."
     )
 
 


### PR DESCRIPTION
This PR updates the `environment.yml` file with a restriction on the Python package that it be strictly less than Python 3.11. The reason is described in Issue #832. I just set up a new Windows machine and created the `ogcore-dev` conda environment. Because Python 3.11 is now released, that was the version that installed. However, when I ran the `run_ogcore_example.py` script, I got the following traceback, which suggests a conflict between OG-Core's current use of Dask and Python 3.11. This makes sense because Python 3.11 has upgrades to how is does asynchronous parallelization.

I ran the example script with this updated restriction in `environment.yml` and it ran fine.
```
Traceback (most recent call last):
  File "C:\Users\Student\Documents\Repos\OG-Core\run_examples\run_ogcore_example.py", line 136, in <module>
    main()
  File "C:\Users\Student\Documents\Repos\OG-Core\run_examples\run_ogcore_example.py", line 28, in main
    client = Client()
             ^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\client.py", line 988, in __init__
    self.start(timeout=timeout)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\client.py", line 1185, in start
    sync(self.loop, self._start, **kwargs)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\utils.py", line 406, in sync
    raise exc.with_traceback(tb)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\utils.py", line 379, in f
    result = yield future
             ^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\tornado\gen.py", line 769, in run
    value = future.result()
            ^^^^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\client.py", line 1251, in _start
    self.cluster = await LocalCluster(
                   ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\spec.py", line 400, in _
    await self._correct_state()
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\spec.py", line 366, in _correct_state_internal
    await asyncio.wait(workers)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\asyncio\tasks.py", line 418, in wait
    return await _wait(fs, timeout, return_when, loop)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\asyncio\tasks.py", line 522, in _wait
    f.add_done_callback(_on_completion)
    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Nanny' object has no attribute 'add_done_callback'
Exception ignored in atexit callback: <function close_clusters at 0x000001BEE8498EA0>
Traceback (most recent call last):
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\spec.py", line 677, in close_clusters
    cluster.close(timeout=10)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\cluster.py", line 217, in close
    return self.sync(self._close, callback_timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\utils.py", line 339, in sync
    return sync(
           ^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\utils.py", line 406, in sync
    raise exc.with_traceback(tb)
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\utils.py", line 379, in f
    result = yield future
             ^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\tornado\gen.py", line 769, in run
    value = future.result()
            ^^^^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\asyncio\tasks.py", line 479, in wait_for
    return fut.result()
           ^^^^^^^^^^^^
  File "C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\spec.py", line 437, in _close
    assert w.status in {
AssertionError: Status.init
Task was destroyed but it is pending!
task: <Task pending name='Task-19' coro=<Cluster._sync_cluster_info() running at C:\Users\Student\.conda\envs\ogcore-dev\Lib\site-packages\distributed\deploy\cluster.py:179> wait_for=<Future pending cb=[Task.task_wakeup()]>>
```

Merging this PR closes #832.

cc: @jdebacker 