### PR TITLE
Update max values for r_gov_scale and r_gov_shift in default_parameters.json

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -837,7 +837,7 @@
         "validators": {
             "range": {
                 "min": 0.0,
-                "max": 2.0
+                "max": 4.0
             }
         }
     },
@@ -855,7 +855,7 @@
         "validators": {
             "range": {
                 "min": 0.0,
-                "max": 0.2
+                "max": 0.3
             }
         }
     },

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -301,8 +301,9 @@ def plot_fert_rates(
     fert_fine_pred = fert_func(age_fine_pred)
     age_fine = np.hstack((min_yr, age_fine_pred, max_yr))
     fert_fine = np.hstack((0, fert_fine_pred, 0))
-    age_mid_new = np.linspace(np.float(max_yr) / totpers, max_yr, totpers) - (
-        0.5 * np.float(max_yr) / totpers
+    age_mid_new = (
+        np.linspace(np.float64(max_yr) / totpers, max_yr, totpers) -
+        (0.5 * np.float64(max_yr) / totpers)
     )
 
     fig, ax = plt.subplots()
@@ -369,8 +370,9 @@ def plot_mort_rates_data(
         fig (Matplotlib plot object): plot of mortality rates
 
     """
-    age_mid_new = np.linspace(np.float(max_yr) / totpers, max_yr, totpers) - (
-        0.5 * np.float(max_yr) / totpers
+    age_mid_new = (
+        np.linspace(np.float64(max_yr) / totpers, max_yr, totpers) -
+        (0.5 * np.float64(max_yr) / totpers)
     )
     fig, ax = plt.subplots()
     plt.scatter(

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -301,10 +301,9 @@ def plot_fert_rates(
     fert_fine_pred = fert_func(age_fine_pred)
     age_fine = np.hstack((min_yr, age_fine_pred, max_yr))
     fert_fine = np.hstack((0, fert_fine_pred, 0))
-    age_mid_new = (
-        np.linspace(np.float64(max_yr) / totpers, max_yr, totpers) -
-        (0.5 * np.float64(max_yr) / totpers)
-    )
+    age_mid_new = np.linspace(
+        np.float64(max_yr) / totpers, max_yr, totpers
+    ) - (0.5 * np.float64(max_yr) / totpers)
 
     fig, ax = plt.subplots()
     plt.scatter(age_midp, fert_data, s=70, c="blue", marker="o", label="Data")
@@ -370,10 +369,9 @@ def plot_mort_rates_data(
         fig (Matplotlib plot object): plot of mortality rates
 
     """
-    age_mid_new = (
-        np.linspace(np.float64(max_yr) / totpers, max_yr, totpers) -
-        (0.5 * np.float64(max_yr) / totpers)
-    )
+    age_mid_new = np.linspace(
+        np.float64(max_yr) / totpers, max_yr, totpers
+    ) - (0.5 * np.float64(max_yr) / totpers)
     fig, ax = plt.subplots()
     plt.scatter(
         np.hstack([0, age_year_all]),


### PR DESCRIPTION
This PR updates the maximum values for `r_gov_scale` and `r_gov_shift` from 2.0 and 0.2, respectively, to 4.0 and 0.3. This is because the calibrated values of these two parameters for the OG-ZAF (South Africa) repository are respectively, 3.37662504 and 0.24484764, which are slightly above the current maxima for these parameters (See [PR #24](https://github.com/EAPD-DRB/OG-ZAF/pull/24) in OG-ZAF by @SeaCelo).

I also updated the references to `np.float()` to be `np.float64` in `parameter_plots.py`. The lack of this change was causing tests to fail in `test_parameter_plots.py`.

cc: @jdebacker 