### PR TITLE
Changed min val of r_gov_shift in default_parameters.json

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -854,7 +854,7 @@
         ],
         "validators": {
             "range": {
-                "min": 0.0,
+                "min": -0.3,
                 "max": 0.3
             }
         }


### PR DESCRIPTION
This PR changes the minimum value of the `r_gov_shift` parameters to be -0.3. So that parameter's values can now range from -0.3 to 0.3.