### PR TITLE
Bump the version to include recent PR in PyPI package

### DIFF
--- a/docs/book/content/contributing/contributor_guide.md
+++ b/docs/book/content/contributing/contributor_guide.md
@@ -186,6 +186,6 @@ A large set of plots that compare the changes among key variables from the basel
 (Sec_ContribFootnotes)=
 ## Footnotes
 
-[^recent_python]:The most recent version of Python from Anaconda is Python 3.9. `OG-Core` is currently tested to run on Python 3.8 through 3.10.
+[^recent_python]:The most recent version of Python from Anaconda is Python 3.9. `OG-Core` is currently tested to run on Python 3.9 through 3.10.
 
 [^commandline_note]:The dollar sign is the end of the command prompt on a Mac. If you are using the Windows operating system, this is usually the right angle bracket (>). No matter the symbol, you don't need to type it (or anything to its left, which shows the current working directory) at the command line before you enter a command; the prompt symbol and preceding characters should already be there.

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -19,4 +19,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.10.1",
+    version="0.10.2",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",


### PR DESCRIPTION
@jdebacker. This PR updates the version of OG-Core so that the most recent PR can be included in the PyPI.org package. This PR updates the version number to 0.10.2 in `setup.py` and `__init__.py`. I also made a small change in the Python versions referenced in `contributor_guide.md`.