### PR TITLE
Fix conditional expression in txfunc.py

### DIFF
--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -1118,8 +1118,14 @@ def plot_2D_taxfunc(
     # get tax rates for each point in the income support and plot
     fig, ax = plt.subplots()
     for i, tax_params in enumerate(tax_param_list):
+        if tax_func_type[i] == "mono":
+            tax_params = tax_params[rate_key][s][t][0]
+        else:
+            tax_param_array = np.array(tax_params[rate_key])
+            tax_params = tax_param_array[s, t, :]
         rates = txfunc.get_tax_rates(
-            tax_params[rate_key][s, t, :],
+            # tax_params[rate_key][s, t, :],
+            tax_params,
             X,
             Y,
             None,

--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -1183,10 +1183,10 @@ def tax_func_loop(
                     ] = lin_int_mtry[s_ind, :]
 
             elif (
-                NoData_cnt
-                > 0 & NoData_cnt
-                < s - s_min & tax_func_type
-                == "mono"
+                (NoData_cnt
+                > 0) & (NoData_cnt
+                < s - s_min) & (tax_func_type
+                == "mono")
             ):
                 # '''
                 # -------------------------------------------------------------

--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -1183,10 +1183,9 @@ def tax_func_loop(
                     ] = lin_int_mtry[s_ind, :]
 
             elif (
-                (NoData_cnt
-                > 0) & (NoData_cnt
-                < s - s_min) & (tax_func_type
-                == "mono")
+                (NoData_cnt > 0)
+                & (NoData_cnt < s - s_min)
+                & (tax_func_type == "mono")
             ):
                 # '''
                 # -------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a bug in a conditional expression in `txfunc.py`.  Given the multiple conditions and the strict equality condition, conditions were not evaluated in the expected way (see [this Stack Overflow thread](https://stackoverflow.com/questions/50656307/numpy-typeerror-ufunc-bitwise-and-not-supported-for-the-input-types-when-us) on the precedence of `&` and `==`).