### PR TITLE
Time varying risk premia

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -310,7 +310,7 @@ def inner_loop(outer_loop_vars, p, client):
     B = aggr.get_B(bssmat, p, "SS", False)
 
     # Find gov't debt
-    r_gov = fiscal.get_r_gov(r, p)
+    r_gov = fiscal.get_r_gov(r, p, "SS")
     D, D_d, D_f, new_borrowing, _, new_borrowing_f = fiscal.get_D_ss(
         r_gov, Y, p
     )
@@ -361,7 +361,7 @@ def inner_loop(outer_loop_vars, p, client):
         new_r = firm.get_r(Y_vec[-1], K_vec[-1], p_m, p, "SS", -1)
     new_w = firm.get_w(Y_vec[-1], L_vec[-1], p_m, p, "SS")
 
-    new_r_gov = fiscal.get_r_gov(new_r, p)
+    new_r_gov = fiscal.get_r_gov(new_r, p, "SS")
     # now get accurate measure of debt service cost
     (
         D,
@@ -658,7 +658,7 @@ def SS_solver(
     K_vec_ss = new_K_vec
     L_vec_ss = new_L_vec
     Y_vec_ss = new_Y_vec
-    r_gov_ss = fiscal.get_r_gov(rss, p)
+    r_gov_ss = fiscal.get_r_gov(rss, p, "SS")
     p_m_ss = new_p_m
     p_i_ss = np.dot(p.io_matrix, p_m_ss)
     p_tilde_ss = aggr.get_ptilde(p_i_ss, p.tau_c[-1, :], p.alpha_c)

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -707,7 +707,6 @@ def run_TPI(p, client=None):
 
     # TPI loop
     while (TPIiter < p.maxiter) and (TPIdist >= p.mindist_TPI):
-
         outer_loop_vars = (r_p, r, w, p_m, BQ, TR, theta)
         # compute composite good price
         p_i = (

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -662,7 +662,7 @@ def run_TPI(p, client=None):
     total_tax_revenue = np.ones(p.T + p.S) * ss_vars["total_tax_revenue"]
 
     # Compute other interest rates
-    r_gov = fiscal.get_r_gov(r, p)
+    r_gov = fiscal.get_r_gov(r, p, "TPI")
     r_p = np.ones_like(r) * ss_vars["r_p_ss"]
     MPKg = np.zeros((p.T, p.M))
     for m in range(p.M):
@@ -936,7 +936,7 @@ def run_TPI(p, client=None):
         )
         # For case where economy is small open econ
         rnew[p.zeta_K == 1] = p.world_int_rate[p.zeta_K == 1]
-        r_gov_new = fiscal.get_r_gov(rnew, p)
+        r_gov_new = fiscal.get_r_gov(rnew, p, "TPI")
         MPKg_vec = np.zeros((p.T, p.M))
         for m in range(p.M):
             MPKg_vec[:, m] = np.squeeze(

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -829,9 +829,10 @@
         "section_1": "Fiscal Policy Parameters",
         "notes": "",
         "type": "float",
+        "number_dims": 1,
         "value": [
             {
-                "value": 1.0
+                "value": [1.0]
             }
         ],
         "validators": {
@@ -847,9 +848,10 @@
         "description": "Parameter to shift the market interest rate to find interest rate on government debt.",
         "notes": "",
         "type": "float",
+        "number_dims": 1,
         "value": [
             {
-                "value": 0.02
+                "value": [0.02]
             }
         ],
         "validators": {

--- a/ogcore/fiscal.py
+++ b/ogcore/fiscal.py
@@ -350,7 +350,7 @@ def get_TR(
     return new_TR
 
 
-def get_r_gov(r, p):
+def get_r_gov(r, p, method):
     r"""
     Determine the interest rate on government debt
 
@@ -367,7 +367,10 @@ def get_r_gov(r, p):
             time path or in the steady-state
 
     """
-    r_gov = np.maximum(p.r_gov_scale * r - p.r_gov_shift, 0.00)
+    if method == "SS":
+        r_gov = np.maximum(p.r_gov_scale[-1] * r - p.r_gov_shift[-1], 0.00)
+    else:
+        r_gov = np.maximum(p.r_gov_scale * r - p.r_gov_shift, 0.00)
 
     return r_gov
 

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -143,6 +143,8 @@ class Specifications(paramtools.Parameters):
             "replacement_rate_adjust",
             "zeta_D",
             "zeta_K",
+            "r_gov_scale",
+            "r_gov_shift"
         ]
         for item in tp_param_list:
             this_attr = getattr(self, item)

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -144,7 +144,7 @@ class Specifications(paramtools.Parameters):
             "zeta_D",
             "zeta_K",
             "r_gov_scale",
-            "r_gov_shift"
+            "r_gov_shift",
         ]
         for item in tp_param_list:
             this_attr = getattr(self, item)

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -158,7 +158,6 @@ def comp_array(name, a, b, tol, unequal, exceptions={}, relative=False):
         return False
 
     else:
-
         if np.all(a < EPSILON) and np.all(b < EPSILON):
             return True
 

--- a/tests/test_fiscal.py
+++ b/tests/test_fiscal.py
@@ -263,7 +263,12 @@ p4 = p3.update_specifications({"r_gov_scale": [0.5], "r_gov_shift": [0.03]})
 
 @pytest.mark.parametrize(
     "r,p,method,r_gov_expected",
-    [(r, p1, "SS", r_gov1), (r, p2, "SS", r_gov2), (r, p3, "SS", r_gov3), (r, p3, "TPI", r_gov3)],
+    [
+        (r, p1, "SS", r_gov1),
+        (r, p2, "SS", r_gov2),
+        (r, p3, "SS", r_gov3),
+        (r, p3, "TPI", r_gov3),
+    ],
     ids=["Scale only", "Scale and shift", "r_gov < 0", "TPI"],
 )
 def test_get_r_gov(r, p, method, r_gov_expected):

--- a/tests/test_fiscal.py
+++ b/tests/test_fiscal.py
@@ -244,27 +244,30 @@ def test_get_TR(
 
 
 p1 = Specifications()
-p1.r_gov_scale = 0.5
-p1.r_gov_shift = 0.0
+p1.r_gov_scale = [0.5]
+p1.r_gov_shift = [0.0]
 p2 = Specifications()
-p2.r_gov_scale = 0.5
-p2.r_gov_shift = 0.01
+p2.r_gov_scale = [0.5]
+p2.r_gov_shift = [0.01]
 p3 = Specifications()
-p3.r_gov_scale = 0.5
-p3.r_gov_shift = 0.03
+p3.r_gov_scale = [0.5]
+p3.r_gov_shift = [0.03]
 r = 0.04
 r_gov1 = 0.02
 r_gov2 = 0.01
 r_gov3 = 0.0
+r_tpi = np.ones(320) * r
+r_gov_tpi = np.ones(320) * r_gov3
+p4 = p3.update_specifications({"r_gov_scale": [0.5], "r_gov_shift": [0.03]})
 
 
 @pytest.mark.parametrize(
-    "r,p,r_gov_expected",
-    [(r, p1, r_gov1), (r, p2, r_gov2), (r, p3, r_gov3)],
-    ids=["Scale only", "Scale and shift", "r_gov < 0"],
+    "r,p,method,r_gov_expected",
+    [(r, p1, "SS", r_gov1), (r, p2, "SS", r_gov2), (r, p3, "SS", r_gov3), (r, p3, "TPI", r_gov3)],
+    ids=["Scale only", "Scale and shift", "r_gov < 0", "TPI"],
 )
-def test_get_r_gov(r, p, r_gov_expected):
-    r_gov = fiscal.get_r_gov(r, p)
+def test_get_r_gov(r, p, method, r_gov_expected):
+    r_gov = fiscal.get_r_gov(r, p, method)
     assert np.allclose(r_gov, r_gov_expected)
 
 

--- a/tests/test_household.py
+++ b/tests/test_household.py
@@ -994,7 +994,6 @@ test_data = [
     "bssmat,nssmat,cssmat,ltilde", test_data, ids=["passing", "failing"]
 )
 def test_constraint_checker_SS(bssmat, nssmat, cssmat, ltilde):
-
     household.constraint_checker_SS(bssmat, nssmat, cssmat, ltilde)
     assert True
 
@@ -1003,7 +1002,6 @@ def test_constraint_checker_SS(bssmat, nssmat, cssmat, ltilde):
     "bssmat,nssmat,cssmat,ltilde", test_data, ids=["passing", "failing"]
 )
 def test_constraint_checker_TPI(bssmat, nssmat, cssmat, ltilde):
-
     household.constraint_checker_TPI(bssmat, nssmat, cssmat, 10, ltilde)
     assert True
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -702,7 +702,6 @@ test_data = [(df1, "tex", 0), (df1, "json", 2), (df1, "html", 3)]
     "df,output_type,precision", test_data, ids=["tex", "json", "html"]
 )
 def test_save_return_table(df, output_type, precision):
-
     test_str = utils.save_return_table(df, output_type, None, precision)
     assert isinstance(test_str, str)
 


### PR DESCRIPTION
This PR allows the `r_gov_scale` and `r_gov_shift` parameters to vary over time.  With this, one can model transitory shocks to the perceived risk of government debt (in a reduced form way since government default is not endogenous in OG-Core).
