### PR TITLE
Remove Unused Dependency: psutil

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,6 @@ dependencies:
 - python>=3.7.7, <3.11  # This restriction can be removed as soon as we test Python 3.11
 - ipython
 - setuptools
-- psutil
 - scipy>=1.7.1
 - pandas>=1.2.5
 - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setuptools.setup(
     include_packages=True,
     python_requires=">=3.7.7, <3.11",
     install_requires=[
-        "psutil",
         "scipy>=1.7.1",
         "pandas>=1.2.5",
         "matplotlib",


### PR DESCRIPTION
## Summary

This pull request proposes the removal of the unused `psutil` dependency from both the `setup.py` configuration file and the `environment.yaml` file. This action is part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects.

## Rationale

The `psutil` library was integrated into the project via 1fba23b. However, its usage was discontinued in a subsequent commit, 8f96a2e. Despite this change in the codebase, `psutil`  continued to be listed in the project's dependency files. Removing this unused dependency can reduce the overall footprint of the application, mitigate potential security risks, and simplify the dependency management process.

## Changes

- Removed the `psutil`  dependency from the `setup.py` file.
- Extracted the `psutil` dependency from the `environment.yaml` under the `ogcore-dev` environment.

## Impact

- Reduced package size: Eliminating this unused dependency will decrease the overall size of the installed packages.

- Simplified dependency tree: A leaner list of dependencies aids in more straightforward project maintenance and faster installations.

