### PR TITLE
Simplify the extrapolation of arrays over the time path

### DIFF
--- a/docs/book/content/api/utils.rst
+++ b/docs/book/content/api/utils.rst
@@ -18,4 +18,4 @@ ogcore.utils
     pickle_file_compare, comp_array, comp_scalar, dict_compare,
     to_timepath_shape, get_initial_path, safe_read_pickle, rate_conversion,
     save_return_table, print_progress, fetch_files_from_web, not_connected,
-    avg_by_bin
+    avg_by_bin, extrapolate_arrays

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -1386,7 +1386,11 @@ def run_SS(p, client=None):
             Yss = TR_ss / p.alpha_T[-1]  # may not be right - if
             # budget_balance = True, but that's ok - will be fixed in
             # SS_solver
-        if ENFORCE_SOLUTION_CHECKS and not sol.success == 1:
+        if (
+            (ENFORCE_SOLUTION_CHECKS)
+            and not (sol.success == 1)
+            and (np.absolute(np.array(sol.fun)).max() > p.mindist_SS)
+        ):
             raise RuntimeError("Steady state equilibrium not found")
         # Return SS values of variables
         fsolve_flag = True

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -242,70 +242,9 @@ class Specifications(paramtools.Parameters):
         # Try to deal with size of eta.  It may vary by S, J, T, but
         # want to allow user to enter one that varies by only S, S and J,
         # S and T, or T and S and J.
-        eta_to_set = getattr(self, "eta")
-        # this is the case that vary only by S
-        if eta_to_set.ndim == 1:
-            assert eta_to_set.shape[0] == self.S
-            eta_to_set = np.tile(
-                (
-                    np.tile(eta_to_set.reshape(self.S, 1), (1, self.J))
-                    / self.J
-                ).reshape(1, self.S, self.J),
-                (self.T + self.S, 1, 1),
-            )
-        # this could be where vary by S and J or T and S
-        elif eta_to_set.ndim == 2:
-            # case if S by J input
-            if eta_to_set.shape[0] == self.S:
-                eta_to_set = np.tile(
-                    eta_to_set.reshape(1, self.S, self.J),
-                    (self.T + self.S, 1, 1),
-                )
-                eta_to_set = eta_to_set = np.concatenate(
-                    (
-                        eta_to_set,
-                        np.tile(
-                            eta_to_set[-1, :, :].reshape(1, self.S, self.J),
-                            (self.S, 1, 1),
-                        ),
-                    ),
-                    axis=0,
-                )
-            # case if T by S input
-            elif eta_to_set.shape[0] == self.T:
-                eta_to_set = (
-                    np.tile(
-                        eta_to_set.reshape(self.T, self.S, 1), (1, 1, self.J)
-                    )
-                    / self.J
-                )
-                eta_to_set = eta_to_set = np.concatenate(
-                    (
-                        eta_to_set,
-                        np.tile(
-                            eta_to_set[-1, :, :].reshape(1, self.S, self.J),
-                            (self.S, 1, 1),
-                        ),
-                    ),
-                    axis=0,
-                )
-            else:
-                print("Eta dimensions are: ", self.eta.shape)
-                print("please give an eta that is either SxJ or TxS")
-                assert False
-        # this is the case where vary by S, J, T
-        elif eta_to_set.ndim == 3:
-            eta_to_set = eta_to_set = np.concatenate(
-                (
-                    eta_to_set,
-                    np.tile(
-                        eta_to_set[-1, :, :].reshape(1, self.S, self.J),
-                        (self.S, 1, 1),
-                    ),
-                ),
-                axis=0,
-            )
-        setattr(self, "eta", eta_to_set)
+        param_in = getattr(self, "eta")
+        param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.S, self.J), item="eta")
+        setattr(self, item, param_out)
 
         # make sure zeta matrix sums to one (e.g., default off due to rounding)
         self.zeta = self.zeta / self.zeta.sum()

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -256,7 +256,7 @@ class Specifications(paramtools.Parameters):
         param_out = extrapolate_arrays(
             param_in, dims=(self.T + self.S, self.S, self.J), item="eta"
         )
-        setattr(self, item, param_out)
+        setattr(self, "eta", param_out)
 
         # make sure zeta matrix sums to one (e.g., default off due to rounding)
         self.zeta = self.zeta / self.zeta.sum()

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -121,7 +121,7 @@ class Specifications(paramtools.Parameters):
         )
 
         # set fraction of income taxes from payroll to zero initially
-        # will be updated when function tax function parameters
+        # will be updated when read in tax function parameters
         if self.T + self.S > self.BW:
             self.frac_tax_payroll = np.append(
                 self.frac_tax_payroll,
@@ -147,24 +147,9 @@ class Specifications(paramtools.Parameters):
             "r_gov_shift",
         ]
         for item in tp_param_list:
-            this_attr = getattr(self, item)
-            if this_attr.ndim > 1:
-                this_attr = np.squeeze(this_attr, axis=1)
-            # the next if statement is a quick fix to avoid having to
-            # update all these time varying parameters if change T or S
-            # ideally, the default json values are read in again and the
-            # extension done is done again here with those defaults and
-            # the new T and S values...
-            if this_attr.size > self.T + self.S:
-                this_attr = this_attr[: self.T + self.S]
-            this_attr = np.concatenate(
-                (
-                    this_attr,
-                    np.ones((self.T + self.S - this_attr.size))
-                    * this_attr[-1],
-                )
-            )
-            setattr(self, item, this_attr)
+            param_in = getattr(self, item)
+            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, ), item=item)
+            setattr(self, item, param_out)
         # Deal with parameters that vary across industry and over time
         tp_param_list2 = [
             "Z",

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -148,7 +148,9 @@ class Specifications(paramtools.Parameters):
         ]
         for item in tp_param_list:
             param_in = getattr(self, item)
-            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, ), item=item)
+            param_out = extrapolate_arrays(
+                param_in, dims=(self.T + self.S,), item=item
+            )
             setattr(self, item, param_out)
         # Deal with parameters that vary across industry and over time
         tp_param_list2 = [
@@ -159,13 +161,17 @@ class Specifications(paramtools.Parameters):
         ]
         for item in tp_param_list2:
             param_in = getattr(self, item)
-            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.M), item=item)
+            param_out = extrapolate_arrays(
+                param_in, dims=(self.T + self.S, self.M), item=item
+            )
             setattr(self, item, param_out)
         # Deal with parameters that vary across consumption good and over time
         tp_param_list3 = ["tau_c"]
         for item in tp_param_list3:
             param_in = getattr(self, item)
-            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.I), item=item)
+            param_out = extrapolate_arrays(
+                param_in, dims=(self.T + self.S, self.I), item=item
+            )
             setattr(self, item, param_out)
         # Deal with parameters that vary across J and over time
         tp_param_list3 = [
@@ -174,7 +180,9 @@ class Specifications(paramtools.Parameters):
         ]
         for item in tp_param_list3:
             param_in = getattr(self, item)
-            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.J), item=item)
+            param_out = extrapolate_arrays(
+                param_in, dims=(self.T + self.S, self.J), item=item
+            )
             setattr(self, item, param_out)
         # Deal with parameters that vary across age and over time
         tp_param_list4 = [
@@ -182,7 +190,9 @@ class Specifications(paramtools.Parameters):
         ]
         for item in tp_param_list4:
             param_in = getattr(self, item)
-            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.S), item=item)
+            param_out = extrapolate_arrays(
+                param_in, dims=(self.T + self.S, self.S), item=item
+            )
             setattr(self, item, param_out)
         # Deal with tax parameters that maybe age and time specific
         tax_params_to_TP = [
@@ -243,7 +253,9 @@ class Specifications(paramtools.Parameters):
         # want to allow user to enter one that varies by only S, S and J,
         # S and T, or T and S and J.
         param_in = getattr(self, "eta")
-        param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.S, self.J), item="eta")
+        param_out = extrapolate_arrays(
+            param_in, dims=(self.T + self.S, self.S, self.J), item="eta"
+        )
         setattr(self, item, param_out)
 
         # make sure zeta matrix sums to one (e.g., default off due to rounding)

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -6,7 +6,7 @@ import paramtools
 
 # import ogcore
 from ogcore import elliptical_u_est
-from ogcore.utils import rate_conversion
+from ogcore.utils import rate_conversion, extrapolate_arrays
 from ogcore.constants import BASELINE_DIR
 
 CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -173,240 +173,32 @@ class Specifications(paramtools.Parameters):
             "inv_tax_credit",
         ]
         for item in tp_param_list2:
-            this_attr = getattr(self, item)
-            if this_attr.ndim == 1:
-                # case where enter single number, so assume constant
-                # across years and industries
-                if this_attr.shape[0] == 1:
-                    this_attr = (
-                        np.ones((self.T + self.S, self.M)) * this_attr[0]
-                    )
-                # case where user enters just one year for all industries
-                if this_attr.shape[0] == self.M:
-                    this_attr = np.tile(
-                        this_attr.reshape(1, self.M), (self.T + self.S, 1)
-                    )
-                else:
-                    # case where user enters multiple years for one industry
-                    # will assume they implied values the same across industries
-                    this_attr = np.concatenate(
-                        (
-                            this_attr,
-                            np.ones((self.T + self.S - this_attr.size))
-                            * this_attr[-1],
-                        )
-                    )
-                    this_attr = np.tile(
-                        this_attr.reshape(self.T + self.S, 1), (1, self.M)
-                    )
-                this_attr = np.squeeze(this_attr, axis=2)
-            elif this_attr.ndim == 2:
-                if this_attr.shape[1] > 1 and this_attr.shape[1] != self.M:
-                    print(
-                        "please provide values of "
-                        + item
-                        + " for each industry (or one if common across "
-                        + "industries}"
-                    )
-                    assert False
-                if this_attr.shape[1] == 1:
-                    this_attr = np.tile(
-                        this_attr.reshape(this_attr.shape[0], 1), (1, self.M)
-                    )
-                if this_attr.shape[0] > self.T + self.S:
-                    this_attr = this_attr[: self.T + self.S, :]
-                this_attr = np.concatenate(
-                    (
-                        this_attr,
-                        np.ones(
-                            (
-                                self.T + self.S - this_attr.shape[0],
-                                this_attr.shape[1],
-                            )
-                        )
-                        * this_attr[-1, :],
-                    )
-                )
-            setattr(self, item, this_attr)
+            param_in = getattr(self, item)
+            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.M), item=item)
+            setattr(self, item, param_out)
         # Deal with parameters that vary across consumption good and over time
         tp_param_list3 = ["tau_c"]
         for item in tp_param_list3:
-            this_attr = getattr(self, item)
-            if this_attr.ndim == 1:
-                # case where enter single number, so assume constant
-                # across years and industries
-                if this_attr.shape[0] == 1:
-                    this_attr = (
-                        np.ones((self.T + self.S, self.I)) * this_attr[0]
-                    )
-                # case where user enters just one year for all industries
-                if this_attr.shape[0] == self.I:
-                    this_attr = np.tile(
-                        this_attr.reshape(1, self.I), (self.T + self.S, 1)
-                    )
-                else:
-                    # case where user enters multiple years for one industry
-                    # will assume they implied values the same across industries
-                    this_attr = np.concatenate(
-                        (
-                            this_attr,
-                            np.ones((self.T + self.S - this_attr.size))
-                            * this_attr[-1],
-                        )
-                    )
-                    this_attr = np.tile(
-                        this_attr.reshape(self.T + self.S, 1), (1, self.I)
-                    )
-                this_attr = np.squeeze(this_attr, axis=2)
-            elif this_attr.ndim == 2:
-                if this_attr.shape[1] > 1 and this_attr.shape[1] != self.I:
-                    print(
-                        "please provide values of "
-                        + item
-                        + " for each industry (or one if common across "
-                        + "industries"
-                    )
-                    assert False
-                if this_attr.shape[1] == 1:
-                    this_attr = np.tile(
-                        this_attr.reshape(this_attr.shape[0], 1), (1, self.I)
-                    )
-                if this_attr.shape[0] > self.T + self.S:
-                    this_attr = this_attr[: self.T + self.S, :]
-                this_attr = np.concatenate(
-                    (
-                        this_attr,
-                        np.ones(
-                            (
-                                self.T + self.S - this_attr.shape[0],
-                                this_attr.shape[1],
-                            )
-                        )
-                        * this_attr[-1, :],
-                    )
-                )
-            setattr(self, item, this_attr)
+            param_in = getattr(self, item)
+            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.I), item=item)
+            setattr(self, item, param_out)
         # Deal with parameters that vary across J and over time
         tp_param_list3 = [
             "labor_income_tax_noncompliance_rate",
             "capital_income_tax_noncompliance_rate",
         ]
         for item in tp_param_list3:
-            this_attr = getattr(self, item)
-            if this_attr.ndim == 1:
-                # case where enter single number, so assume constant
-                # across years and J
-                if this_attr.shape[0] == 1:
-                    this_attr = (
-                        np.ones((self.T + self.S, self.J)) * this_attr[0]
-                    )
-                # case where user enters just one year for all J
-                if this_attr.shape[0] == self.J:
-                    this_attr = np.tile(
-                        this_attr.reshape(1, self.J), (self.T + self.S, 1)
-                    )
-                else:
-                    # case where user enters multiple years for one J
-                    # will assume they implied values the same across J
-                    this_attr = np.concatenate(
-                        (
-                            this_attr,
-                            np.ones((self.T + self.S - this_attr.size))
-                            * this_attr[-1],
-                        )
-                    )
-                    this_attr = np.tile(
-                        this_attr.reshape(self.T + self.S, 1), (1, self.J)
-                    )
-                this_attr = np.squeeze(this_attr, axis=2)
-            elif this_attr.ndim == 2:
-                if this_attr.shape[1] > 1 and this_attr.shape[1] != self.J:
-                    print(
-                        "please provide values of "
-                        + item
-                        + " for each j (or one if common across "
-                        + "ability groups)"
-                    )
-                    assert False
-                if this_attr.shape[1] == 1:
-                    this_attr = np.tile(
-                        this_attr.reshape(this_attr.shape[0], 1), (1, self.J)
-                    )
-                if this_attr.shape[0] > self.T + self.S:
-                    this_attr = this_attr[: self.T + self.S, :]
-                this_attr = np.concatenate(
-                    (
-                        this_attr,
-                        np.ones(
-                            (
-                                self.T + self.S - this_attr.shape[0],
-                                this_attr.shape[1],
-                            )
-                        )
-                        * this_attr[-1, :],
-                    )
-                )
-            setattr(self, item, this_attr)
+            param_in = getattr(self, item)
+            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.J), item=item)
+            setattr(self, item, param_out)
         # Deal with parameters that vary across age and over time
         tp_param_list4 = [
             "rho",
         ]
         for item in tp_param_list4:
-            this_attr = getattr(self, item)
-            if this_attr.ndim == 1:
-                # case where enter single number, so assume constant
-                # across years and age
-                if this_attr.shape[0] == 1:
-                    this_attr = (
-                        np.ones((self.T + self.S, self.S)) * this_attr[0]
-                    )
-                # case where user enters just one year for all ages
-                if this_attr.shape[0] == self.S:
-                    this_attr = np.tile(
-                        this_attr.reshape(1, self.S), (self.T + self.S, 1)
-                    )
-                else:
-                    # case where user enters multiple years for one age
-                    # will assume they implied values the same across
-                    # time for all periods after the last year of values
-                    this_attr = np.concatenate(
-                        (
-                            this_attr,
-                            np.ones((self.T + self.S - this_attr.size))
-                            * this_attr[-1],
-                        )
-                    )
-                    this_attr = np.tile(
-                        this_attr.reshape(self.T + self.S, 1), (1, self.S)
-                    )
-            elif this_attr.ndim == 2:
-                if this_attr.shape[1] > 1 and this_attr.shape[1] != self.S:
-                    print(
-                        "please provide values of "
-                        + item
-                        + " for each age (or one if common across "
-                        + "S}"
-                    )
-                    assert False
-                if this_attr.shape[1] == 1:
-                    this_attr = np.tile(
-                        this_attr.reshape(this_attr.shape[0], 1), (1, self.S)
-                    )
-                if this_attr.shape[0] > self.T + self.S:
-                    this_attr = this_attr[: self.T + self.S, :]
-                this_attr = np.concatenate(
-                    (
-                        this_attr,
-                        np.ones(
-                            (
-                                self.T + self.S - this_attr.shape[0],
-                                this_attr.shape[1],
-                            )
-                        )
-                        * this_attr[-1, :],
-                    )
-                )
-            setattr(self, item, this_attr)
+            param_in = getattr(self, item)
+            param_out = extrapolate_arrays(param_in, dims=(self.T + self.S, self.S), item=item)
+            setattr(self, item, param_out)
         # Deal with tax parameters that maybe age and time specific
         tax_params_to_TP = [
             "etr_params",

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -917,8 +917,7 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
         param_out = np.concatenate(
             (
                 param_in,
-                np.ones((dims[0] - param_in.size))
-                * param_in[-1],
+                np.ones((dims[0] - param_in.size)) * param_in[-1],
             )
         )
     elif len(dims) == 2:
@@ -928,14 +927,10 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
             # case where enter single number, so assume constant
             # across all dimensions
             if param_in.shape[0] == 1:
-                param_out = (
-                    np.ones((dims)) * param_in[0]
-                )
+                param_out = np.ones((dims)) * param_in[0]
             # case where user enters just one year for all types in 2nd dim
             if param_in.shape[0] == dims[1]:
-                param_in = np.tile(
-                    param_in.reshape(1, dims[1]), (dims[0], 1)
-                )
+                param_in = np.tile(param_in.reshape(1, dims[1]), (dims[0], 1))
             else:
                 # case where user enters multiple years, but not full time
                 # path
@@ -944,13 +939,10 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
                 param_in = np.concatenate(
                     (
                         param_in,
-                        np.ones((dims[0] - param_in.size))
-                        * param_in[-1],
+                        np.ones((dims[0] - param_in.size)) * param_in[-1],
                     )
                 )
-                param_in = np.tile(
-                    param_in.reshape(dims[0], 1), (1, dims[1])
-                )
+                param_in = np.tile(param_in.reshape(dims[0], 1), (1, dims[1]))
             param_out = np.squeeze(param_in, axis=2)
         elif param_in.ndim == 2:
             # case where enter values along 2 dimensions, but those aren't
@@ -1020,7 +1012,8 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
             elif param_in.shape[0] == dims[0] - dims[1]:
                 param_in = (
                     np.tile(
-                        param_in.reshape(dims[0] - dims[1], dims[1], 1), (1, 1, dims[2])
+                        param_in.reshape(dims[0] - dims[1], dims[1], 1),
+                        (1, 1, dims[2]),
                     )
                     / dims[2]
                 )

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -908,67 +908,82 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
     Returns:
         param_out (array_like): reshape parameter for use in OG-Core
     """
-    assert something here: that input array be single value or match up with at least one dim
-    if param_in.ndim == 1:
-        # case where enter single number, so assume constant
-        # across all dimensions
-        if param_in.shape[0] == 1:
-            param_out = (
-                np.ones((dims)) * param_in[0]
-            )
-        # case where user enters just one year for all types in 2nd dim
-        if param_in.shape[0] == dims[1]:
-            param_in = np.tile(
-                param_in.reshape(1, dims[1]), (dims[0], 1)
-            )
-        else:
-            # case where user enters multiple years, but not full time
-            # path
-            # will assume they implied values the same across 2nd dim
-            # and will fill in all periods
-            param_in = np.concatenate(
-                (
-                    param_in,
-                    np.ones((dims[0] - param_in.size))
-                    * param_in[-1],
-                )
-            )
-            param_in = np.tile(
-                param_in.reshape(dims[0], 1), (1, dims[1])
-            )
-        param_out = np.squeeze(param_in, axis=2)
-    elif param_in.ndim == 2:
-        # case where enter values along 2 dimensions, but those aren't
-        # complete
-        if param_in.shape[1] > 1 and param_in.shape[1] != dims[1]:
-            print(
-                "please provide values of "
-                + item
-                + " for element in the 2nd dimension (or enter a "
-                + "constant if the value is common across elements in "
-                + "the second dimension}"
-            )
-            assert False
-        if param_in.shape[1] == 1:
-            # Case where enter just one value along the 2nd dim, will
-            # assume constant across it
-            param_in = np.tile(
-                param_in.reshape(param_in.shape[0], 1), (1, dims[1])
-            )
-        if param_in.shape[0] > dims[0]:
-            # Case where enter a number of values along the time
-            # dimension that exceeds the length of the time path
-            param_in = param_in[: dims[0], :]
+    if len(dims) == 1:
+        # this is the case for 1D arrays, they vary over the time path
+        if param_in.ndim > 1:
+            param_in = np.squeeze(param_in, axis=1)
+        if param_in.size > dims[0]:
+            param_in = param_in[: dims[0]]
         param_out = np.concatenate(
             (
                 param_in,
-                np.ones(
-                    (
-                        dims[0] - param_in.shape[0],
-                        param_in.shape[1],
-                    )
-                )
-                * param_in[-1, :],
+                np.ones((dims[0] - param_in.size))
+                * param_in[-1],
             )
         )
+    elif len(dims) == 2:
+        # this is the case for 2D arrays, they vary over the time path
+        # and and some other dimension (e.g., by industry)
+        if param_in.ndim == 1:
+            # case where enter single number, so assume constant
+            # across all dimensions
+            if param_in.shape[0] == 1:
+                param_out = (
+                    np.ones((dims)) * param_in[0]
+                )
+            # case where user enters just one year for all types in 2nd dim
+            if param_in.shape[0] == dims[1]:
+                param_in = np.tile(
+                    param_in.reshape(1, dims[1]), (dims[0], 1)
+                )
+            else:
+                # case where user enters multiple years, but not full time
+                # path
+                # will assume they implied values the same across 2nd dim
+                # and will fill in all periods
+                param_in = np.concatenate(
+                    (
+                        param_in,
+                        np.ones((dims[0] - param_in.size))
+                        * param_in[-1],
+                    )
+                )
+                param_in = np.tile(
+                    param_in.reshape(dims[0], 1), (1, dims[1])
+                )
+            param_out = np.squeeze(param_in, axis=2)
+        elif param_in.ndim == 2:
+            # case where enter values along 2 dimensions, but those aren't
+            # complete
+            if param_in.shape[1] > 1 and param_in.shape[1] != dims[1]:
+                print(
+                    "please provide values of "
+                    + item
+                    + " for element in the 2nd dimension (or enter a "
+                    + "constant if the value is common across elements in "
+                    + "the second dimension}"
+                )
+                assert False
+            if param_in.shape[1] == 1:
+                # Case where enter just one value along the 2nd dim, will
+                # assume constant across it
+                param_in = np.tile(
+                    param_in.reshape(param_in.shape[0], 1), (1, dims[1])
+                )
+            if param_in.shape[0] > dims[0]:
+                # Case where enter a number of values along the time
+                # dimension that exceeds the length of the time path
+                param_in = param_in[: dims[0], :]
+            param_out = np.concatenate(
+                (
+                    param_in,
+                    np.ones(
+                        (
+                            dims[0] - param_in.shape[0],
+                            param_in.shape[1],
+                        )
+                    )
+                    * param_in[-1, :],
+                )
+            )
     return param_out

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -982,6 +982,7 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
         # this is the case for 3D arrays, they vary over the time path
         # and two other dimensions (e.g., by age and ability type)
         if param_in.ndim == 1:
+            # case if S x 1 input
             assert param_in.shape[0] == dims[1]
             param_out = np.tile(
                 (
@@ -1031,8 +1032,8 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
                 print(item + " dimensions are: ", param_in.shape)
                 print("please give an " + item + " that is either SxJ or TxS")
                 assert False
-        # this is the case where vary by T, S, J
         elif param_in.ndim == 3:
+            # this is the case where input varies by T, S, J
             param_out = np.concatenate(
                 (
                     param_in,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -791,3 +791,24 @@ def test_avg_by_bin():
     assert np.allclose(x_binned, x_expected)
     assert np.allclose(y_binned, y_expected)
     assert np.allclose(weights_binned, weights_expected)
+
+
+test_data = [
+    (np.array([[2.3]]), (4, 3), np.ones((4,3)) * 2.3),
+    (np.array([[2.3, 2.3, 2.3]]), (4, 3), np.ones((4,3)) * 2.3),
+    (np.array([[2.3], [2.3], [2.3]]), (4, 3), np.ones((4,3)) * 2.3),
+]
+
+
+@pytest.mark.parametrize(
+    "param_in,dims,expected", test_data, ids=["scalar in", "1D in", "2D in"]
+)
+def test_extrapolate_arrays(param_in, dims, expected):
+    """
+    Test of the utils.extrapolate_arrays function
+    """
+    test_value = utils.extrapolate_arrays(
+        param_in, dims=dims
+        )
+
+    assert np.allclose(test_value, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -798,11 +798,13 @@ test_data = [
     (np.array([[2.3, 2.3, 2.3]]), (4, 3), np.ones((4,3)) * 2.3),
     (np.array([[2.3], [2.3], [2.3]]), (4, 3), np.ones((4,3)) * 2.3),
     (np.array([2.3, 2.3]), (4,), np.ones(4) * 2.3),
+    (np.array([[2.3, 2.3], [2.3, 2.3], [2.3, 2.3]]), (4, 3, 2), np.ones((4, 3, 2)) * 2.3),
+    # (np.array([[2.3, 2.3, 2.3], [2.3, 2.3, 2.3]]), (4, 3, 2), np.ones((4, 3, 2)) * 2.3), use this one to test assert error
 ]
 
 
 @pytest.mark.parametrize(
-    "param_in,dims,expected", test_data, ids=["scalar in", "1D in", "2D in", "1D out"]
+    "param_in,dims,expected", test_data, ids=["2D, scalar in", "2D, 1D in", "2D in", "1D out", "3D out"]
 )
 def test_extrapolate_arrays(param_in, dims, expected):
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -794,24 +794,28 @@ def test_avg_by_bin():
 
 
 test_data = [
-    (np.array([[2.3]]), (4, 3), np.ones((4,3)) * 2.3),
-    (np.array([[2.3, 2.3, 2.3]]), (4, 3), np.ones((4,3)) * 2.3),
-    (np.array([[2.3], [2.3], [2.3]]), (4, 3), np.ones((4,3)) * 2.3),
+    (np.array([[2.3]]), (4, 3), np.ones((4, 3)) * 2.3),
+    (np.array([[2.3, 2.3, 2.3]]), (4, 3), np.ones((4, 3)) * 2.3),
+    (np.array([[2.3], [2.3], [2.3]]), (4, 3), np.ones((4, 3)) * 2.3),
     (np.array([2.3, 2.3]), (4,), np.ones(4) * 2.3),
-    (np.array([[2.3, 2.3], [2.3, 2.3], [2.3, 2.3]]), (4, 3, 2), np.ones((4, 3, 2)) * 2.3),
+    (
+        np.array([[2.3, 2.3], [2.3, 2.3], [2.3, 2.3]]),
+        (4, 3, 2),
+        np.ones((4, 3, 2)) * 2.3,
+    ),
     # (np.array([[2.3, 2.3, 2.3], [2.3, 2.3, 2.3]]), (4, 3, 2), np.ones((4, 3, 2)) * 2.3), use this one to test assert error
 ]
 
 
 @pytest.mark.parametrize(
-    "param_in,dims,expected", test_data, ids=["2D, scalar in", "2D, 1D in", "2D in", "1D out", "3D out"]
+    "param_in,dims,expected",
+    test_data,
+    ids=["2D, scalar in", "2D, 1D in", "2D in", "1D out", "3D out"],
 )
 def test_extrapolate_arrays(param_in, dims, expected):
     """
     Test of the utils.extrapolate_arrays function
     """
-    test_value = utils.extrapolate_arrays(
-        param_in, dims=dims
-        )
+    test_value = utils.extrapolate_arrays(param_in, dims=dims)
 
     assert np.allclose(test_value, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -797,11 +797,12 @@ test_data = [
     (np.array([[2.3]]), (4, 3), np.ones((4,3)) * 2.3),
     (np.array([[2.3, 2.3, 2.3]]), (4, 3), np.ones((4,3)) * 2.3),
     (np.array([[2.3], [2.3], [2.3]]), (4, 3), np.ones((4,3)) * 2.3),
+    (np.array([2.3, 2.3]), (4,), np.ones(4) * 2.3),
 ]
 
 
 @pytest.mark.parametrize(
-    "param_in,dims,expected", test_data, ids=["scalar in", "1D in", "2D in"]
+    "param_in,dims,expected", test_data, ids=["scalar in", "1D in", "2D in", "1D out"]
 )
 def test_extrapolate_arrays(param_in, dims, expected):
     """


### PR DESCRIPTION
This PR simplifies the code in `parameters.py` by creating a new function in `utils.py` that handles the extrapolation of parameters that vary over the time path.  

There are not substantive changes to the code here, just making this extrapolation code more clear and compact.