### PR TITLE
Create a demographics module in OG-Core

### DIFF
--- a/docs/book/content/theory/images/SS_images.py
+++ b/docs/book/content/theory/images/SS_images.py
@@ -4,6 +4,7 @@ This script creates the plots for the steady-state chapter of the OG-Core
 documentation
 ------------------------------------------------------------------------
 """
+
 # Import libraries, packages, and modules
 import pickle
 import os

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -481,9 +481,6 @@ def inner_loop(outer_loop_vars, p, client):
         debt_service,
         p,
     )
-    print("Agg tax = ", total_tax_revenue)
-    print("Agg pension outlays = ", agg_pension_outlays)
-    print("Agg UBI outlays = ", UBI_outlays)
     new_TR = fiscal.get_TR(
         Y,
         TR,

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -1,6 +1,7 @@
 """
 Specify what is available to import from the ogcore package.
 """
+
 from ogcore.SS import *
 from ogcore.TPI import *
 from ogcore.aggregates import *

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -484,7 +484,7 @@ def get_pop_objs(
                 path, length T + S
 
     """
-    print("Model year = ", model_year, " Data year = ", data_year)
+    print("Model year = ", model_year, ", Inital Data year = ", initial_data_year, ", Final Data year = ", final_data_year)
     assert model_year >= 2011 and model_year <= 2100
     assert initial_data_year >= 2011 and initial_data_year <= 2100
     assert final_data_year >= 2011 and final_data_year <= 2100
@@ -526,6 +526,7 @@ def get_pop_objs(
     # the implicit assumption is that they are constant after the
     # last year of UN or user provided data
     mort_rates = np.hstack(mort_rates, np.tile(mort_rates[-1, :], T - mort_rates.shape[0]))
+    mort_rates_S = mort_rates
     if imm_rates is None:
         imm_rates_orig = get_imm_rates(
             E + S, min_age, max_age, country_id, initial_data_year,
@@ -560,7 +561,7 @@ def get_pop_objs(
     # Generate time path of the nonstationary population distribution
     omega_path_lev = np.zeros((E + S, T + S))
     pop_data = get_un_data(
-        "47", country_id=country_id, start_year=data_year, end_year=data_year
+        "47", country_id=country_id, start_year=inital_data_year, end_year=initial_data_year
     )
     # TODO: allow one to read in multiple years of UN forecast then
     # extrapolate from the end of that
@@ -580,7 +581,7 @@ def get_pop_objs(
         -S:
     ].sum()  # g_n in data year
     pop_past = pop_curr
-    for per in range(model_year - data_year):
+    for per in range(model_year - initial_data_year):
         pop_next = np.dot(OMEGA_orig, pop_curr)
         g_n_curr = (pop_next[-S:].sum() - pop_curr[-S:].sum()) / pop_curr[
             -S:

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -268,10 +268,8 @@ def pop_rebin(curr_pop_dist, totpers_new):
 
     # Number of periods in original data
     totpers_orig = len(curr_pop_dist)
-    print("CHECK lengths", totpers_new, totpers_orig)
     if int(totpers_new) == totpers_orig:
         curr_pop_new = curr_pop_dist
-        print("SAme length, ", totpers_new)
     elif int(totpers_new) < totpers_orig:
         num_sub_bins = float(10000)
         curr_pop_sub = np.repeat(
@@ -286,7 +284,6 @@ def pop_rebin(curr_pop_dist, totpers_new):
             curr_pop_new[i] = curr_pop_sub[beg_sub_bin:end_sub_bin].sum()
         # Return curr_pop_new to single precision float (float32)
         # datatype
-        print("dfif length", totpers_new, totpers_orig)
         curr_pop_new = np.float32(curr_pop_new)
 
     return curr_pop_new
@@ -567,8 +564,6 @@ def get_pop_objs(
         ),
         axis=0,
     )
-    print("Inf mort rates = ", infmort_rates)
-    print("Infmort rates shape", infmort_rates.shape)
     infmort_rates = np.concatenate((
         infmort_rates, np.tile(infmort_rates[-1], (T - infmort_rates.shape[0]))))
     mort_rates_S = mort_rates[:, E:]
@@ -637,7 +632,6 @@ def get_pop_objs(
             start_year=y,
             end_year=y,
         )
-        print("pop data ages = ", pop_data.age.min(), pop_data.age.max())
         pop_data_sample = pop_data[
             (pop_data["age"] >= min_age) & (pop_data["age"] <= max_age)
         ]
@@ -645,7 +639,6 @@ def get_pop_objs(
         # Generate the current population distribution given that E+S might
         # be less than max_age-min_age+1
         # age_per_EpS = np.arange(1, E + S + 1)
-        print("SHAPING: ", min_age, max_age, E+S, pop.shape)
         pop_EpS = pop_rebin(pop, E + S)
         pop_pct = pop_EpS / pop_EpS.sum()
         pop_2D[y - initial_data_year, :] = pop_EpS

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -352,7 +352,9 @@ def get_imm_rates(
         # back out imm rates by age for each year
         newborns = np.dot(fert_rates[y - start_year, :], pop_t)
         # new born imm_rate
-        imm_rates[0] = (pop_tp1[0] - (1 - mort_rates[y - start_year, 0]) * newborns) / pop_t[0]
+        imm_rates[0] = (
+            pop_tp1[0] - (1 - mort_rates[y - start_year, 0]) * newborns
+        ) / pop_t[0]
         # all other age imm_rates
         imm_rates[1:] = (
             pop_tp1[1:] - (1 - mort_rates[y - start_year, :-1]) * pop_t[:-1]
@@ -424,7 +426,7 @@ def get_pop_objs(
     min_age=0,
     max_age=100,
     initial_data_year=START_YEAR - 1,
-    final_data_year=START_YEAR + 100, # as default data year goes until T1
+    final_data_year=START_YEAR + 100,  # as default data year goes until T1
     country_id=UN_COUNTRY_CODE,
     imm_rates=None,
     mort_rates=None,
@@ -477,7 +479,9 @@ def get_pop_objs(
 
     """
     # TODO: this function does not generalize with T.  It assumes one model period is equal to one calendar year in the time dimesion (it does adjust for S, however)
-    T0 = final_data_year - initial_data_year + 1  # number of periods until constant fertility and mortality rates
+    T0 = (
+        final_data_year - initial_data_year + 1
+    )  # number of periods until constant fertility and mortality rates
     print(
         ", Inital Data year = ",
         initial_data_year,
@@ -631,7 +635,8 @@ def get_pop_objs(
         end_year=initial_data_year - 1,
     )
     pre_pop_sample = pre_pop_data[
-        (pre_pop_data["age"] >= min_age - 1) & (pre_pop_data["age"] <= max_age - 1)
+        (pre_pop_data["age"] >= min_age - 1)
+        & (pre_pop_data["age"] <= max_age - 1)
     ]
     pre_pop = pre_pop_sample.value.values
     pre_pop_EpS = pop_rebin(pre_pop, E + S)
@@ -651,7 +656,9 @@ def get_pop_objs(
     # steady-state distribution by adjusting immigration rates, holding
     # constant mortality, fertility, and SS growth rates
     imm_tol = 1e-14
-    fixper = int(1.5 * S)  # TODO: probably move out 1.5*S to sometime after/relative to T0 (final data year)
+    fixper = int(
+        1.5 * S
+    )  # TODO: probably move out 1.5*S to sometime after/relative to T0 (final data year)
     omega_SSfx = omega_path_lev[fixper, :] / omega_path_lev[fixper, :].sum()
     imm_objs = (
         fert_rates[fixper, :],
@@ -681,10 +688,9 @@ def get_pop_objs(
         - omega_path_lev[:-1, -S:].sum(axis=1)
     ) / omega_path_lev[:-1, -S:].sum(axis=1)
     g_n_path[0] = (
-        omega_path_lev[0, -S:].sum()
-        - pre_pop_EpS[-S:].sum()
+        omega_path_lev[0, -S:].sum() - pre_pop_EpS[-S:].sum()
     ) / pre_pop_EpS[-S:].sum()
-    g_n_path[fixper + 1:] = g_n_SS
+    g_n_path[fixper + 1 :] = g_n_SS
     omega_S_preTP = pre_pop_EpS[-S:] / pre_pop_EpS[-S:].sum()
     # imm_rates_mat = np.hstack(
     #     (
@@ -839,17 +845,17 @@ def get_pop_objs(
             S,
             output_dir=OUTPUT_DIR,
         )
-# TODO: get dimensions right in what follows:
-        # pp.plot_population_path(
-        #     age_per_EpS,
-        #     pop_pct,
-        #     omega_path_lev,
-        #     omega_SSfx,
-        #     initial_data_year,
-        #     E,
-        #     S,
-        #     output_dir=OUTPUT_DIR,
-        # )
+        # TODO: get dimensions right in what follows:
+        pp.plot_population_path(
+            age_per_EpS,
+            pop_pct,
+            omega_path_lev,
+            omega_SSfx,
+            initial_data_year,
+            initial_data_year,
+            S,
+            output_dir=OUTPUT_DIR,
+        )
 
     # return omega_path_S, g_n_SS, omega_SSfx, survival rates,
     # mort_rates_S, and g_n_path

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -339,27 +339,25 @@ def get_imm_rates(
     for y in range(start_year, end_year + 1):
         # need to read UN population data by age for each year
         df = get_un_data("47", country_id=country_id, start_year=y, end_year=y)
-        pop_t = df[
-            (df.year == start_year + t) & (df.age <= 100) & (df.age > 0)
-        ].value.values
+        pop_t = df[(df.age <= 100) & (df.age > 0)].value.values
         pop_t = pop_rebin(pop_t, totpers)
         df = get_un_data(
             "47", country_id=country_id, start_year=y + 1, end_year=y + 1
         )
-        pop_tp1 = df.value.values
+        pop_tp1 = df[(df.age <= 100) & (df.age > 0)].value.values
         pop_tp1 = pop_rebin(pop_tp1, totpers)
 
-        # initiize imm_rate vector
+        # initialize imm_rate vector
         imm_rates = np.zeros(totpers)
         # back out imm rates by age for each year
-        newbornvec = np.dot(fert_rates, pop_t)
+        newbornvec = np.dot(fert_rates[y - start_year, :], pop_t)
         # new born imm_rate
-        imm_rates[0] = (pop_tp1[0] - (1 - mort_rates[0]) * newbornvec) / pop_t[
+        imm_rates[0] = (pop_tp1[0] - (1 - mort_rates[y - start_year, 0]) * newbornvec) / pop_t[
             0
         ]
         # all other age imm_rates
         imm_rates[1:] = (
-            pop_tp1[1:] - (1 - mort_rates[1:]) * pop_t[1:]
+            pop_tp1[1:] - (1 - mort_rates[y - start_year, 1:]) * pop_t[1:]
         ) / pop_t[1:]
 
         imm_rates_2D[y - start_year, :] = imm_rates

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -347,7 +347,9 @@ def get_imm_rates(
     for y in range(start_year, end_year + 1):
         if pop_dist is None:
             # need to read UN population data by age for each year
-            df = get_un_data("47", country_id=country_id, start_year=y, end_year=y)
+            df = get_un_data(
+                "47", country_id=country_id, start_year=y, end_year=y
+            )
             pop_t = df[(df.age < 100) & (df.age >= 0)].value.values
             pop_t = pop_rebin(pop_t, totpers)
             df = get_un_data(
@@ -441,7 +443,7 @@ def get_pop_objs(
     initial_data_year=START_YEAR - 1,
     final_data_year=START_YEAR + 2,  # as default data year goes until T1
     country_id=UN_COUNTRY_CODE,
-    imm_rates=None, #TODO: change order of these args to be consistent with other functions
+    imm_rates=None,  # TODO: change order of these args to be consistent with other functions
     mort_rates=None,
     infmort_rates=None,
     fert_rates=None,
@@ -513,7 +515,9 @@ def get_pop_objs(
     # Really, it will need to be well before this
     assert final_data_year > initial_data_year
     assert final_data_year < initial_data_year + T
-    assert T > 2 * T0  # ensure time path 2x as long as allows rates to fluctuate
+    assert (
+        T > 2 * T0
+    )  # ensure time path 2x as long as allows rates to fluctuate
 
     # Get fertility, mortality, and immigration rates
     # will be used to generate population distribution in future years
@@ -682,10 +686,12 @@ def get_pop_objs(
             # find newborns next period
             newborns = np.dot(fert_rates[t - 1, :], pop_counter_2D[t - 1, :])
 
-            pop_counter_2D[t, 0] =  (1 - infmort_rates[t-1]) * newborns + imm_rates[t-1,0] * pop_counter_2D[t-1, 0]
+            pop_counter_2D[t, 0] = (
+                1 - infmort_rates[t - 1]
+            ) * newborns + imm_rates[t - 1, 0] * pop_counter_2D[t - 1, 0]
             pop_counter_2D[t, 1:] = (
-                pop_counter_2D[t - 1, :-1] * (1 - mort_rates[t - 1, :-1]) +
-                pop_counter_2D[t - 1, 1:] * imm_rates_orig[t - 1, 1:]
+                pop_counter_2D[t - 1, :-1] * (1 - mort_rates[t - 1, :-1])
+                + pop_counter_2D[t - 1, 1:] * imm_rates_orig[t - 1, 1:]
             )
         # Check that counterfactual pop dist is close to pop dist given
         assert np.allclose(pop_counter_2D, pop_dist)
@@ -712,9 +718,7 @@ def get_pop_objs(
     # steady-state distribution by adjusting immigration rates, holding
     # constant mortality, fertility, and SS growth rates
     imm_tol = 1e-14
-    fixper = int(
-        1.5 * S + T0
-    )
+    fixper = int(1.5 * S + T0)
     omega_SSfx = omega_path_lev[fixper, :] / omega_path_lev[fixper, :].sum()
     imm_objs = (
         fert_rates[fixper, :],

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -641,7 +641,15 @@ def get_pop_objs(
     mort_rates_S = mort_rates[:, E:]
     # Get population distribution if not provided
     if pop_dist is None:
-        pop_2D, pre_pop = get_pop(E, S, min_age, max_age, country_id, initial_data_year, final_data_year)
+        pop_2D, pre_pop = get_pop(
+            E,
+            S,
+            min_age,
+            max_age,
+            country_id,
+            initial_data_year,
+            final_data_year,
+        )
     else:
         # Check first dims of pop_dist as input by user
         assert pop_dist.shape[0] == T0

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -860,12 +860,12 @@ def get_pop_objs(
     # return omega_path_S, g_n_SS, omega_SSfx, survival rates,
     # mort_rates_S, and g_n_path
     pop_dict = {
-        "omega": omega_path_S.T,
+        "omega": omega_path_S,
         "g_n_ss": g_n_SS,
         "omega_SS": omega_SSfx[-S:] / omega_SSfx[-S:].sum(),
         "rho": [mort_rates_S],
         "g_n": g_n_path,
-        "imm_rates": imm_rates_mat.T,
+        "imm_rates": imm_rates_mat,
         "omega_S_preTP": omega_S_preTP,
     }
 

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -160,7 +160,7 @@ def get_fert(
                 fert_rates_2D,
                 start_year,
                 [start_year, end_year],
-                output_dir=plot_path,
+                path=plot_path,
             )
             return fert_rates_2D
         else:
@@ -229,7 +229,7 @@ def get_mort(
                 mort_rates_2D,
                 start_year,
                 [start_year, end_year],
-                output_dir=plot_path,
+                path=plot_path,
             )
             return mort_rates_2D, infmort_rate
         else:
@@ -369,7 +369,7 @@ def get_imm_rates(
                 imm_rates_2D,
                 start_year,
                 [start_year, end_year],
-                output_dir=plot_path,
+                path=plot_path,
             )
             return imm_rates_2D
         else:
@@ -832,7 +832,7 @@ def get_pop_objs(
         # plots
         age_per_EpS = np.arange(1, E + S + 1)
         pp.plot_omega_fixed(
-            age_per_EpS, omega_SS_orig, omega_SSfx, E, S, output_dir=OUTPUT_DIR
+            age_per_EpS, omega_SS_orig, omega_SSfx, E, S, path=OUTPUT_DIR
         )
         pp.plot_imm_fixed(
             age_per_EpS,
@@ -840,7 +840,7 @@ def get_pop_objs(
             imm_rates_adj,
             E,
             S,
-            output_dir=OUTPUT_DIR,
+            path=OUTPUT_DIR,
         )
         # TODO: get dimensions right in what follows:
         pp.plot_population_path(
@@ -851,7 +851,7 @@ def get_pop_objs(
             initial_data_year,
             initial_data_year,
             S,
-            output_dir=OUTPUT_DIR,
+            path=OUTPUT_DIR,
         )
 
     # return omega_path_S, g_n_SS, omega_SSfx, survival rates,

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -1,0 +1,768 @@
+"""
+------------------------------------------------------------------------
+Functions for generating demographic objects necessary for the OG-USA
+model
+------------------------------------------------------------------------
+"""
+# Import packages
+import os
+import numpy as np
+import scipy.optimize as opt
+import pandas as pd
+import matplotlib.pyplot as plt
+from ogusa.utils import get_legacy_session
+from ogcore import parameter_plots as pp
+
+START_YEAR = 2023
+END_YEAR = 2023
+UN_COUNTRY_CODE = "840"  # UN code for USA
+# create output director for figures
+CUR_PATH = os.path.split(os.path.abspath(__file__))[0]
+OUTPUT_DIR = os.path.join(CUR_PATH, "..", "data", "OUTPUT", "Demographics")
+if os.access(OUTPUT_DIR, os.F_OK) is False:
+    os.makedirs(OUTPUT_DIR)
+
+
+"""
+------------------------------------------------------------------------
+Define functions
+------------------------------------------------------------------------
+"""
+
+
+def get_un_data(
+    variable_code,
+    country_id=UN_COUNTRY_CODE,
+    start_year=START_YEAR,
+    end_year=END_YEAR,
+):
+    """
+    This function retrieves data from the United Nations Data Portal API
+    for UN population data (see
+    https://population.un.org/dataportal/about/dataapi)
+
+    Args:
+        variable_code (str): variable code for UN data
+        country_id (str): country id for UN data
+        start_year (int): start year for UN data
+        end_year (int): end year for UN data
+
+    Returns:
+        df (Pandas DataFrame): DataFrame of UN data
+    """
+    target = (
+        "https://population.un.org/dataportalapi/api/v1/data/indicators/"
+        + variable_code
+        + "/locations/"
+        + country_id
+        + "/start/"
+        + str(start_year)
+        + "/end/"
+        + str(end_year)
+    )
+
+    # get data from url
+    response = get_legacy_session().get(target)
+    # Check if the request was successful before processing
+    if response.status_code == 200:
+        # Converts call into JSON
+        j = response.json()
+        # Convert JSON into a pandas DataFrame.
+        # pd.json_normalize flattens the JSON to accommodate nested lists
+        # within the JSON structure
+        df = pd.json_normalize(j["data"])
+        # Loop until there are new pages with data
+        while j["nextPage"] is not None:
+            # Reset the target to the next page
+            target = j["nextPage"]
+            # call the API for the next page
+            response = get_legacy_session().get(target)
+            # Convert response to JSON format
+            j = response.json()
+            # Store the next page in a data frame
+            df_temp = pd.json_normalize(j["data"])
+            # Append next page to the data frame
+            df = pd.concat([df, df_temp])
+        # keep just what is needed from data
+        df = df[df.variant == "Median"]
+        df = df[df.sex == "Both sexes"][["timeLabel", "ageLabel", "value"]]
+        df.rename(
+            {"timeLabel": "year", "ageLabel": "age"}, axis=1, inplace=True
+        )
+        df.loc[df.age == "100+", "age"] = 100
+        df.age = df.age.astype(int)
+        df.year = df.year.astype(int)
+        df = df[df.age <= 100]
+    else:
+        print(
+            f"Failed to retrieve population data. HTTP status code: {response.status_code}"
+        )
+        assert False
+
+    return df
+
+
+def get_fert(
+    totpers=100,
+    min_age=0,
+    max_age=100,
+    country_id=UN_COUNTRY_CODE,
+    start_year=START_YEAR,
+    end_year=END_YEAR,
+    graph=False,
+):
+    """
+    This function generates a vector of fertility rates by model period
+    age that corresponds to the fertility rate data by age in years.
+
+    Args:
+        totpers (int): total number of agent life periods (E+S), >= 3
+        min_age (int): age in years at which agents are born, >= 0
+        max_age (int): age in years at which agents die with certainty,
+            >= 4
+        country_id (str): country id for UN data
+        start_year (int): start year for UN data
+        end_year (int): end year for UN data
+        graph (bool): =True if want graphical output
+
+    Returns:
+        fert_rates (Numpy array): fertility rates for each model period
+            of life
+
+    """
+    # Read UN data
+    df = get_un_data(
+        "68", country_id=country_id, start_year=start_year, end_year=end_year
+    )
+    # put in vector
+    fert_rates = df.value.values
+    # fill in with zeros for ages  < 15 and > 49
+    # NOTE: this assumes min_year < 15 and max_age > 49
+    fert_rates = np.append(fert_rates, np.zeros(max_age - 49))
+    fert_rates = np.append(np.zeros(15 - min_age), fert_rates)
+    # divide by 1000 because fertility rates are number of births per
+    # 1000 woman and we want births per person (might update to account
+    # from fraction men more correctly - below assumes 50/50 men and women)
+    fert_rates = fert_rates / 2000
+    # Rebin data in the case that model period not equal to one calendar
+    # year
+    fert_rates = pop_rebin(fert_rates, totpers)
+
+    # if graph:  # need to fix plot function for new data output
+    #     pp.plot_fert_rates(fert_rates, age_midp, totpers, min_age, max_age,
+    #                        fert_rates, fert_rates, output_dir=OUTPUT_DIR)
+
+    if graph:
+        output_dir = OUTPUT_DIR
+        # Using pyplot here until update to OG-Core mort rates plotting function
+        plt.plot(
+            np.arange(totpers),
+            fert_rates,
+        )
+        plt.xlabel(r"Age $s$")
+        plt.ylabel(r"Fertility rate")
+        plt.legend(loc="upper left")
+        fontdict = {"fontsize": 9}
+        plt.text(
+            -5,
+            -0.2,
+            "Source: United Nations Population Prospects.",
+            **fontdict,
+        )
+        plt.tight_layout(rect=(0, 0.03, 1, 1))
+        output_path = os.path.join(output_dir, "fert_rates")
+        plt.savefig(output_path)
+        plt.close()
+
+    return fert_rates
+
+
+def get_mort(
+    totpers=100,
+    min_age=0,
+    max_age=100,
+    country_id=UN_COUNTRY_CODE,
+    start_year=START_YEAR,
+    end_year=END_YEAR,
+    graph=False,
+):
+    """
+    This function generates a vector of mortality rates by model period
+    age.
+
+    Args:
+        totpers (int): total number of agent life periods (E+S), >= 3
+        min_age (int): age in years at which agents are born, >= 0
+        max_age (int): age in years at which agents die with certainty,
+            >= 4
+        country_id (str): country id for UN data
+        start_year (int): start year for UN data
+        end_year (int): end year for UN data
+        graph (bool): =True if want graphical output
+
+    Returns:
+        mort_rates (Numpy array) mortality rates that correspond to each
+            period of life
+        infmort_rate (scalar): infant mortality rate
+
+    """
+    # Read UN data
+    df = get_un_data(
+        "80", country_id=country_id, start_year=start_year, end_year=end_year
+    )
+    # put in vector
+    mort_rates_data = df.value.values
+    # In UN data, mortality rates for 0 year olds are the infant
+    # mortality rates
+    infmort_rate = mort_rates_data[0]
+    # Rebin data in the case that model period not equal to one calendar
+    # year
+    mort_rates = pop_rebin(mort_rates_data[1:], totpers)
+
+    # Mortality rate in last period is set to 1
+    mort_rates[-1] = 1
+
+    if graph:
+        output_dir = OUTPUT_DIR
+        # Using pyplot here until update to OG-Core mort rates plotting function
+        plt.plot(
+            df.age.values,
+            mort_rates_data,
+        )
+        plt.xlabel(r"Age $s$")
+        plt.ylabel(r"Mortality rate $\rho_{s}$")
+        plt.legend(loc="upper left")
+        fontdict = {"fontsize": 9}
+        plt.text(
+            -5,
+            -0.2,
+            "Source: United Nations Population Prospects.",
+            **fontdict,
+        )
+        plt.tight_layout(rect=(0, 0.03, 1, 1))
+        # Save or return figure
+        if output_dir:
+            output_path = os.path.join(output_dir, "mort_rates")
+            plt.savefig(output_path)
+            plt.close()
+        else:
+            plt.show()
+
+    return mort_rates, infmort_rate
+
+
+def pop_rebin(curr_pop_dist, totpers_new):
+    """
+    For cases in which totpers (E+S) is less than the number of periods
+    in the population distribution data, this function calculates a new
+    population distribution vector with totpers (E+S) elements.
+
+    Args:
+        curr_pop_dist (Numpy array): population distribution over N
+            periods
+        totpers_new (int): number of periods to which we are
+            transforming the population distribution, >= 3
+
+    Returns:
+        curr_pop_new (Numpy array): new population distribution over
+            totpers (E+S) periods that approximates curr_pop_dist
+
+    """
+    # Number of periods in original data
+    assert totpers_new >= 3
+    # Number of periods in original data
+    totpers_orig = len(curr_pop_dist)
+    if int(totpers_new) == totpers_orig:
+        curr_pop_new = curr_pop_dist
+    elif int(totpers_new) < totpers_orig:
+        num_sub_bins = float(10000)
+        curr_pop_sub = np.repeat(
+            np.float64(curr_pop_dist) / num_sub_bins, num_sub_bins
+        )
+        len_subbins = (np.float64(totpers_orig * num_sub_bins)) / totpers_new
+        curr_pop_new = np.zeros(totpers_new, dtype=np.float64)
+        end_sub_bin = 0
+        for i in range(totpers_new):
+            beg_sub_bin = int(end_sub_bin)
+            end_sub_bin = int(np.rint((i + 1) * len_subbins))
+            curr_pop_new[i] = curr_pop_sub[beg_sub_bin:end_sub_bin].sum()
+        # Return curr_pop_new to single precision float (float32)
+        # datatype
+        curr_pop_new = np.float32(curr_pop_new)
+
+    return curr_pop_new
+
+
+def get_imm_rates(
+    totpers=100,
+    min_age=0,
+    max_age=100,
+    country_id=UN_COUNTRY_CODE,
+    start_year=START_YEAR,
+    end_year=END_YEAR,
+    graph=False,
+):
+    """
+    Calculate immigration rates by age as a residual given population
+    levels in different periods, then output average calculated
+    immigration rate. We have to replace the first mortality rate in
+    this function in order to adjust the first implied immigration rate
+
+    Args:
+        totpers (int): total number of agent life periods (E+S), >= 3
+        min_age (int): age in years at which agents are born, >= 0
+        max_age (int): age in years at which agents die with certainty,
+            >= 4
+        country_id (str): country id for UN data
+        start_year (int): start year for UN data
+        end_year (int): end year for UN data
+        graph (bool): =True if want graphical output
+
+    Returns:
+        imm_rates (Numpy array):immigration rates that correspond to
+            each period of life, length E+S
+
+    """
+    # Read UN data
+    num_years = 4  # note that code below only uses four years, in future, this should be more flexbile
+    imm_start_year = (
+        start_year - num_years
+    )  # year to start finding residual imm rate
+    imm_end_year = (
+        start_year + num_years - 1
+    )  # last year to find residual imm rate
+    df = get_un_data(
+        "47",
+        country_id=country_id,
+        start_year=imm_start_year,
+        end_year=imm_end_year,
+    )
+
+    # separate pop dist by year and put into dictionary of arrays
+    pop_dict = {}
+    for t in range(num_years):
+        pop_dist = df[
+            (df.year == start_year + t) & (df.age <= 100) & (df.age > 0)
+        ].value.values
+        pop_dict[t] = pop_rebin(pop_dist, totpers)
+        pop_dict[t] = pop_dist
+
+    # Create num_years - 1 years of estimated immigration rates for youngest age
+    # individuals
+    imm_mat = np.zeros((num_years - 1, totpers))
+    pop_list = []
+    for t in range(num_years):
+        pop_list.append(pop_dict[t][0])
+    pop11vec = np.array(pop_list[:-1])
+    pop21vec = np.array(pop_list[1:])
+    fert_rates = get_fert(
+        totpers, min_age, max_age, country_id, start_year, end_year, False
+    )
+    mort_rates, infmort_rate = get_mort(
+        totpers, min_age, max_age, country_id, start_year, end_year, False
+    )
+    newbornvec = np.dot(
+        fert_rates, np.vstack((pop_dict[0], pop_dict[1], pop_dict[2])).T
+    )
+    imm_mat[:, 0] = (pop21vec - (1 - infmort_rate) * newbornvec) / pop11vec
+    # Estimate num_years - 1 years of immigration rates for all other-aged
+    # individuals
+    pop_mat_dict = {}
+    pop_mat_dict[0] = np.vstack(
+        (pop_dict[0][:-1], pop_dict[1][:-1], pop_dict[2][:-1])
+    )
+    pop_mat_dict[1] = np.vstack(
+        (pop_dict[0][1:], pop_dict[1][1:], pop_dict[2][1:])
+    )
+    pop_mat_dict[2] = np.vstack(
+        (pop_dict[1][1:], pop_dict[2][1:], pop_dict[3][1:])
+    )
+    mort_mat = np.tile(mort_rates[:-1], (num_years - 1, 1))
+    imm_mat[:, 1:] = (
+        pop_mat_dict[2] - (1 - mort_mat) * pop_mat_dict[0]
+    ) / pop_mat_dict[1]
+    # Final estimated immigration rates are the averages over 3 years
+    imm_rates = imm_mat.mean(axis=0)
+
+    if graph:
+        output_dir = OUTPUT_DIR
+        # Using pyplot here until update to OG-Core mort rates plotting function
+        plt.plot(
+            np.arange(totpers),
+            imm_rates,
+            label="Estimated",
+        )
+        plt.xlabel(r"Age $s$")
+        plt.ylabel(r"Immigration Rates")
+        plt.legend(loc="upper left")
+        fontdict = {"fontsize": 9}
+        plt.text(
+            -5,
+            -0.2,
+            "Source: United Nations Population Prospects.",
+            **fontdict,
+        )
+        plt.tight_layout(rect=(0, 0.03, 1, 1))
+        output_path = os.path.join(output_dir, "imm_rates_w_un_data.png")
+        plt.savefig(output_path)
+        plt.close()
+
+    return imm_rates
+
+
+def immsolve(imm_rates, *args):
+    """
+    This function generates a vector of errors representing the
+    difference in two consecutive periods stationary population
+    distributions. This vector of differences is the zero-function
+    objective used to solve for the immigration rates vector, similar to
+    the original immigration rates vector from get_imm_rates(), that
+    sets the steady-state population distribution by age equal to the
+    population distribution in period int(1.5*S)
+
+    Args:
+        imm_rates (Numpy array):immigration rates that correspond to
+            each period of life, length E+S
+        args (tuple): (fert_rates, mort_rates, infmort_rate, omega_cur,
+            g_n_SS)
+
+    Returns:
+        omega_errs (Numpy array): difference between omega_new and
+            omega_cur_pct, length E+S
+
+    """
+    fert_rates, mort_rates, infmort_rate, omega_cur_lev, g_n_SS = args
+    omega_cur_pct = omega_cur_lev / omega_cur_lev.sum()
+    totpers = len(fert_rates)
+    OMEGA = np.zeros((totpers, totpers))
+    OMEGA[0, :] = (1 - infmort_rate) * fert_rates + np.hstack(
+        (imm_rates[0], np.zeros(totpers - 1))
+    )
+    OMEGA[1:, :-1] += np.diag(1 - mort_rates[:-1])
+    OMEGA[1:, 1:] += np.diag(imm_rates[1:])
+    omega_new = np.dot(OMEGA, omega_cur_pct) / (1 + g_n_SS)
+    omega_errs = omega_new - omega_cur_pct
+
+    return omega_errs
+
+
+def get_pop_objs(
+    E=20,
+    S=80,
+    T=320,
+    min_age=0,
+    max_age=100,
+    data_year=START_YEAR - 1,
+    model_year=START_YEAR,
+    country_id=UN_COUNTRY_CODE,
+    GraphDiag=True,
+):
+    """
+    This function produces the demographics objects to be used in the
+    OG-USA model package.
+
+    Args:
+        E (int): number of model periods in which agent is not
+            economically active, >= 1
+        S (int): number of model periods in which agent is economically
+            active, >= 3
+        T (int): number of periods to be simulated in TPI, > 2*S
+        min_age (int): age in years at which agents are born, >= 0
+        max_age (int): age in years at which agents die with certainty,
+            >= 4
+        model_year (int): current year for which analysis will begin,
+            >= 2016
+        country_id (str): country id for UN data
+        GraphDiag (bool): =True if want graphical output and printed
+                diagnostics
+
+    Returns:
+        pop_dict (dict): includes:
+            omega_path_S (Numpy array), time path of the population
+                distribution from the current state to the steady-state,
+                size T+S x S
+            g_n_SS (scalar): steady-state population growth rate
+            omega_SS (Numpy array): normalized steady-state population
+                distribution, length S
+            surv_rates (Numpy array): survival rates that correspond to
+                each model period of life, length S
+            mort_rates (Numpy array): mortality rates that correspond to
+                each model period of life, length S
+            g_n_path (Numpy array): population growth rates over the time
+                path, length T + S
+
+    """
+    print("Model year = ", model_year, " Data year = ", data_year)
+    assert model_year >= 2011 and model_year <= 2100
+    assert data_year >= 2011 and data_year <= 2100
+    # need data year to be before model year to get omega_S_preTP
+    assert data_year < model_year
+
+    # Get fertility, mortality, and immigration rates
+    # will be used to generate population distribution in future years
+    fert_rates = get_fert(
+        E + S, min_age, max_age, country_id, data_year, data_year
+    )
+    mort_rates, infmort_rate = get_mort(
+        E + S, min_age, max_age, country_id, data_year, data_year
+    )
+    mort_rates_S = mort_rates[-S:]
+    imm_rates_orig = get_imm_rates(
+        E + S, min_age, max_age, country_id, data_year, data_year
+    )
+    OMEGA_orig = np.zeros((E + S, E + S))
+    OMEGA_orig[0, :] = (1 - infmort_rate) * fert_rates + np.hstack(
+        (imm_rates_orig[0], np.zeros(E + S - 1))
+    )
+    OMEGA_orig[1:, :-1] += np.diag(1 - mort_rates[:-1])
+    OMEGA_orig[1:, 1:] += np.diag(imm_rates_orig[1:])
+
+    # Solve for steady-state population growth rate and steady-state
+    # population distribution by age using eigenvalue and eigenvector
+    # decomposition
+    eigvalues, eigvectors = np.linalg.eig(OMEGA_orig)
+    g_n_SS = (eigvalues[np.isreal(eigvalues)].real).max() - 1
+    eigvec_raw = eigvectors[
+        :, (eigvalues[np.isreal(eigvalues)].real).argmax()
+    ].real
+    omega_SS_orig = eigvec_raw / eigvec_raw.sum()
+
+    # Generate time path of the nonstationary population distribution
+    omega_path_lev = np.zeros((E + S, T + S))
+    pop_data = get_un_data(
+        "47", country_id=country_id, start_year=data_year, end_year=data_year
+    )
+    # TODO: allow one to read in multiple years of UN forecast then
+    # extrapolate from the end of that
+    pop_data_sample = pop_data[
+        (pop_data["age"] >= min_age - 1) & (pop_data["age"] <= max_age - 1)
+    ]
+    pop = pop_data_sample.value.values
+    # Generate the current population distribution given that E+S might
+    # be less than max_age-min_age+1
+    age_per_EpS = np.arange(1, E + S + 1)
+    pop_EpS = pop_rebin(pop, E + S)
+    pop_pct = pop_EpS / pop_EpS.sum()
+    # Age the data to the model year
+    pop_curr = pop_EpS.copy()
+    pop_next = np.dot(OMEGA_orig, pop_curr)
+    g_n_curr = (pop_next[-S:].sum() - pop_curr[-S:].sum()) / pop_curr[
+        -S:
+    ].sum()  # g_n in data year
+    pop_past = pop_curr
+    for per in range(model_year - data_year):
+        pop_next = np.dot(OMEGA_orig, pop_curr)
+        g_n_curr = (pop_next[-S:].sum() - pop_curr[-S:].sum()) / pop_curr[
+            -S:
+        ].sum()
+        pop_past = pop_curr
+        pop_curr = pop_next
+    # Generate time path of the population distribution
+    omega_path_lev[:, 0] = pop_curr.copy()
+    for per in range(1, T + S):
+        pop_next = np.dot(OMEGA_orig, pop_curr)
+        omega_path_lev[:, per] = pop_next.copy()
+        pop_curr = pop_next.copy()
+
+    # Force the population distribution after 1.5*S periods to be the
+    # steady-state distribution by adjusting immigration rates, holding
+    # constant mortality, fertility, and SS growth rates
+    imm_tol = 1e-14
+    fixper = int(1.5 * S)
+    omega_SSfx = omega_path_lev[:, fixper] / omega_path_lev[:, fixper].sum()
+    imm_objs = (
+        fert_rates,
+        mort_rates,
+        infmort_rate,
+        omega_path_lev[:, fixper],
+        g_n_SS,
+    )
+    imm_fulloutput = opt.fsolve(
+        immsolve,
+        imm_rates_orig,
+        args=(imm_objs),
+        full_output=True,
+        xtol=imm_tol,
+    )
+    imm_rates_adj = imm_fulloutput[0]
+    imm_diagdict = imm_fulloutput[1]
+    omega_path_S = omega_path_lev[-S:, :] / np.tile(
+        omega_path_lev[-S:, :].sum(axis=0), (S, 1)
+    )
+    omega_path_S[:, fixper:] = np.tile(
+        omega_path_S[:, fixper].reshape((S, 1)), (1, T + S - fixper)
+    )
+    g_n_path = np.zeros(T + S)
+    g_n_path[0] = g_n_curr.copy()
+    g_n_path[1:] = (
+        omega_path_lev[-S:, 1:].sum(axis=0)
+        - omega_path_lev[-S:, :-1].sum(axis=0)
+    ) / omega_path_lev[-S:, :-1].sum(axis=0)
+    g_n_path[fixper + 1 :] = g_n_SS
+    omega_S_preTP = (pop_past.copy()[-S:]) / (pop_past.copy()[-S:].sum())
+    imm_rates_mat = np.hstack(
+        (
+            np.tile(np.reshape(imm_rates_orig[E:], (S, 1)), (1, fixper)),
+            np.tile(
+                np.reshape(imm_rates_adj[E:], (S, 1)), (1, T + S - fixper)
+            ),
+        )
+    )
+
+    if GraphDiag:
+        # Check whether original SS population distribution is close to
+        # the period-T population distribution
+        omegaSSmaxdif = np.absolute(
+            omega_SS_orig - (omega_path_lev[:, T] / omega_path_lev[:, T].sum())
+        ).max()
+        if omegaSSmaxdif > 0.0003:
+            print(
+                "POP. WARNING: Max. abs. dist. between original SS "
+                + "pop. dist'n and period-T pop. dist'n is greater than"
+                + " 0.0003. It is "
+                + str(omegaSSmaxdif)
+                + "."
+            )
+        else:
+            print(
+                "POP. SUCCESS: orig. SS pop. dist is very close to "
+                + "period-T pop. dist'n. The maximum absolute "
+                + "difference is "
+                + str(omegaSSmaxdif)
+                + "."
+            )
+
+        # Plot the adjusted steady-state population distribution versus
+        # the original population distribution. The difference should be
+        # small
+        omegaSSvTmaxdiff = np.absolute(omega_SS_orig - omega_SSfx).max()
+        if omegaSSvTmaxdiff > 0.0003:
+            print(
+                "POP. WARNING: The maximum absolute difference "
+                + "between any two corresponding points in the original"
+                + " and adjusted steady-state population "
+                + "distributions is"
+                + str(omegaSSvTmaxdiff)
+                + ", "
+                + "which is greater than 0.0003."
+            )
+        else:
+            print(
+                "POP. SUCCESS: The maximum absolute difference "
+                + "between any two corresponding points in the original"
+                + " and adjusted steady-state population "
+                + "distributions is "
+                + str(omegaSSvTmaxdiff)
+            )
+
+        # Print whether or not the adjusted immigration rates solved the
+        # zero condition
+        immtol_solved = np.absolute(imm_diagdict["fvec"].max()) < imm_tol
+        if immtol_solved:
+            print(
+                "POP. SUCCESS: Adjusted immigration rates solved "
+                + "with maximum absolute error of "
+                + str(np.absolute(imm_diagdict["fvec"].max()))
+                + ", which is less than the tolerance of "
+                + str(imm_tol)
+            )
+        else:
+            print(
+                "POP. WARNING: Adjusted immigration rates did not "
+                + "solve. Maximum absolute error of "
+                + str(np.absolute(imm_diagdict["fvec"].max()))
+                + " is greater than the tolerance of "
+                + str(imm_tol)
+            )
+
+        # Test whether the steady-state growth rates implied by the
+        # adjusted OMEGA matrix equals the steady-state growth rate of
+        # the original OMEGA matrix
+        OMEGA2 = np.zeros((E + S, E + S))
+        OMEGA2[0, :] = (1 - infmort_rate) * fert_rates + np.hstack(
+            (imm_rates_adj[0], np.zeros(E + S - 1))
+        )
+        OMEGA2[1:, :-1] += np.diag(1 - mort_rates[:-1])
+        OMEGA2[1:, 1:] += np.diag(imm_rates_adj[1:])
+        eigvalues2, eigvectors2 = np.linalg.eig(OMEGA2)
+        g_n_SS_adj = (eigvalues[np.isreal(eigvalues2)].real).max() - 1
+        if np.max(np.absolute(g_n_SS_adj - g_n_SS)) > 10 ** (-8):
+            print(
+                "FAILURE: The steady-state population growth rate"
+                + " from adjusted OMEGA is different (diff is "
+                + str(g_n_SS_adj - g_n_SS)
+                + ") than the steady-"
+                + "state population growth rate from the original"
+                + " OMEGA."
+            )
+        elif np.max(np.absolute(g_n_SS_adj - g_n_SS)) <= 10 ** (-8):
+            print(
+                "SUCCESS: The steady-state population growth rate"
+                + " from adjusted OMEGA is close to (diff is "
+                + str(g_n_SS_adj - g_n_SS)
+                + ") the steady-"
+                + "state population growth rate from the original"
+                + " OMEGA."
+            )
+
+        # Do another test of the adjusted immigration rates. Create the
+        # new OMEGA matrix implied by the new immigration rates. Plug in
+        # the adjusted steady-state population distribution. Hit is with
+        # the new OMEGA transition matrix and it should return the new
+        # steady-state population distribution
+        omega_new = np.dot(OMEGA2, omega_SSfx)
+        omega_errs = np.absolute(omega_new - omega_SSfx)
+        print(
+            "The maximum absolute difference between the adjusted "
+            + "steady-state population distribution and the "
+            + "distribution generated by hitting the adjusted OMEGA "
+            + "transition matrix is "
+            + str(omega_errs.max())
+        )
+
+        # Plot the original immigration rates versus the adjusted
+        # immigration rates
+        immratesmaxdiff = np.absolute(imm_rates_orig - imm_rates_adj).max()
+        print(
+            "The maximum absolute distance between any two points "
+            + "of the original immigration rates and adjusted "
+            + "immigration rates is "
+            + str(immratesmaxdiff)
+        )
+
+        # plots
+        pp.plot_omega_fixed(
+            age_per_EpS, omega_SS_orig, omega_SSfx, E, S, output_dir=OUTPUT_DIR
+        )
+        pp.plot_imm_fixed(
+            age_per_EpS,
+            imm_rates_orig,
+            imm_rates_adj,
+            E,
+            S,
+            output_dir=OUTPUT_DIR,
+        )
+        pp.plot_population_path(
+            age_per_EpS,
+            pop_pct,
+            omega_path_lev,
+            omega_SSfx,
+            model_year,
+            E,
+            S,
+            output_dir=OUTPUT_DIR,
+        )
+
+    # return omega_path_S, g_n_SS, omega_SSfx, survival rates,
+    # mort_rates_S, and g_n_path
+    pop_dict = {
+        "omega": omega_path_S.T,
+        "g_n_ss": g_n_SS,
+        "omega_SS": omega_SSfx[-S:] / omega_SSfx[-S:].sum(),
+        "rho": [mort_rates_S],
+        "g_n": g_n_path,
+        "imm_rates": imm_rates_mat.T,
+        "omega_S_preTP": omega_S_preTP,
+    }
+
+    return pop_dict

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -93,7 +93,7 @@ def get_un_data(
         df.loc[df.age == "100+", "age"] = 100
         df.age = df.age.astype(int)
         df.year = df.year.astype(int)
-        df = df[df.age < 100] # need to drop 100+ age category
+        df = df[df.age < 100]  # need to drop 100+ age category
     else:
         print(
             f"Failed to retrieve population data. HTTP status code: {response.status_code}"
@@ -564,8 +564,12 @@ def get_pop_objs(
         ),
         axis=0,
     )
-    infmort_rates = np.concatenate((
-        infmort_rates, np.tile(infmort_rates[-1], (T - infmort_rates.shape[0]))))
+    infmort_rates = np.concatenate(
+        (
+            infmort_rates,
+            np.tile(infmort_rates[-1], (T - infmort_rates.shape[0])),
+        )
+    )
     mort_rates_S = mort_rates[:, E:]
     if imm_rates is None:
         imm_rates_orig = get_imm_rates(
@@ -616,7 +620,6 @@ def get_pop_objs(
     ].real
     omega_SS_orig = eigvec_raw / eigvec_raw.sum()
 
-
     # TODO: add a "if pop_dist is None" and an else statement below
     # so that it reads in user provided data
     # BUT, will want a test to make sure pop data consistent with fert, mort, imm rates...
@@ -651,8 +654,7 @@ def get_pop_objs(
         end_year=initial_data_year - 1,
     )
     pre_pop_sample = pre_pop_data[
-        (pre_pop_data["age"] >= min_age)
-        & (pre_pop_data["age"] <= max_age)
+        (pre_pop_data["age"] >= min_age) & (pre_pop_data["age"] <= max_age)
     ]
     pre_pop = pre_pop_sample.value.values
     pre_pop_EpS = pop_rebin(pre_pop, E + S)

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -160,9 +160,6 @@ def get_fert(
                 fert_rates_2D,
                 start_year,
                 [start_year, end_year],
-                totpers,
-                min_age,
-                max_age,
                 output_dir=plot_path,
             )
             return fert_rates_2D
@@ -171,9 +168,6 @@ def get_fert(
                 fert_rates_2D,
                 start_year,
                 [start_year, end_year],
-                totpers,
-                min_age,
-                max_age,
             )
             return fert_rates_2D, fig
     else:
@@ -235,9 +229,6 @@ def get_mort(
                 mort_rates_2D,
                 start_year,
                 [start_year, end_year],
-                totpers,
-                min_age,
-                max_age,
                 output_dir=plot_path,
             )
             return mort_rates_2D, infmort_rate
@@ -246,9 +237,6 @@ def get_mort(
                 mort_rates_2D,
                 start_year,
                 [start_year, end_year],
-                totpers,
-                min_age,
-                max_age,
             )
             return mort_rates_2D, infmort_rate, fig
     else:

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -590,6 +590,7 @@ def get_pop_objs(
         axis=0,
     )
     # Create the transition matrix for the population distribution
+    # from T0 going forward (i.e., past when we have data on forecasts)
     OMEGA_orig = np.zeros((E + S, E + S))
     OMEGA_orig[0, :] = (1 - infmort_rate) * fert_rates[-1, :] + np.hstack(
         (imm_rates_orig[-1, 0], np.zeros(E + S - 1))
@@ -631,10 +632,13 @@ def get_pop_objs(
         pop_2D[y - initial_data_year, :] = pop_EpS
 
     # Generate time path of the population distribution after final year of data
-    omega_path_lev[:, 0] = pop_curr.copy()
-    for per in range(1, T + S):
+    omega_path_lev = np.zeros((T + S, E + S))
+    pop_curr = pop_2D[T0, :]
+    omega_path_lev[:T0, :] = pop_2D
+    omega_path_lev[T0, 0] = pop_curr
+    for per in range(T0 + 1, T + S):
         pop_next = np.dot(OMEGA_orig, pop_curr)
-        omega_path_lev[:, per] = pop_next.copy()
+        omega_path_lev[per, :] = pop_next.copy()
         pop_curr = pop_next.copy()
 
     # Force the population distribution after 1.5*S periods to be the

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -507,7 +507,6 @@ def get_pop_objs(
             initial_data_year,
             final_data_year,
         )
-        print("Fert rates shape = ", fert_rates.shape)
     else:
         # ensure that user provided fert_rates are of the correct shape
         assert fert_rates.shape[0] < T0
@@ -525,7 +524,6 @@ def get_pop_objs(
         ),
         axis=0,
     )
-    print("Fert rates shape after tile = ", fert_rates.shape)
     if mort_rates is None:
         # get mort rates from UN data from initial year to data year
         mort_rates, infmort_rate = get_mort(
@@ -536,7 +534,6 @@ def get_pop_objs(
             initial_data_year,
             final_data_year,
         )
-        print("Mort rates shape = ", mort_rates.shape)
     # mort_rates_S = mort_rates[-S:]  #TODO: think about this line
     else:
         # ensure that user provided mort_rates are of the correct shape

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -4,6 +4,7 @@ Functions for generating demographic objects necessary for the OG-USA
 model
 ------------------------------------------------------------------------
 """
+
 # Import packages
 import os
 import numpy as np

--- a/ogcore/elliptical_u_est.py
+++ b/ogcore/elliptical_u_est.py
@@ -5,6 +5,7 @@ parameters of the elliptical utility fuction that correspond to a
 constant Frisch elasticity function with the input Frisch elasticity.
 ------------------------------------------------------------------------
 """
+
 # Import packages
 import numpy as np
 import scipy.optimize as opt

--- a/ogcore/execute.py
+++ b/ogcore/execute.py
@@ -1,6 +1,7 @@
 """
 This module defines the runner() function, which is used to run OG-Core
 """
+
 import pickle
 import cloudpickle
 import os

--- a/ogcore/firm.py
+++ b/ogcore/firm.py
@@ -96,12 +96,7 @@ def get_Y(K, K_g, L, p, method, m=-1):
                     * (L ** ((epsilon - 1) / epsilon))
                 )
             ) ** (epsilon / (epsilon - 1))
-            Y2 = (
-                Z
-                * (K**gamma)
-                * (K_g**gamma_g)
-                * (L ** (1 - gamma - gamma_g))
-            )
+            Y2 = Z * (K**gamma) * (K_g**gamma_g) * (L ** (1 - gamma - gamma_g))
             Y[epsilon == 1] = Y2[epsilon == 1]
     else:  # TPI case
         if m is not None:
@@ -157,12 +152,7 @@ def get_Y(K, K_g, L, p, method, m=-1):
                     * (L ** ((epsilon - 1) / epsilon))
                 )
             ) ** (epsilon / (epsilon - 1))
-            Y2 = (
-                Z
-                * (K**gamma)
-                * (K_g**gamma_g)
-                * (L ** (1 - gamma - gamma_g))
-            )
+            Y2 = Z * (K**gamma) * (K_g**gamma_g) * (L ** (1 - gamma - gamma_g))
             Y[:, epsilon == 1] = Y2[:, epsilon == 1]
 
     return Y
@@ -463,9 +453,7 @@ def get_L_from_Y(w, Y, p, method):
         Z = p.Z[-1]
     else:
         Z = p.Z[: p.T]
-    L = ((1 - p.gamma - p.gamma_g) * Z ** (p.epsilon - 1) * Y) / (
-        w**p.epsilon
-    )
+    L = ((1 - p.gamma - p.gamma_g) * Z ** (p.epsilon - 1) * Y) / (w**p.epsilon)
 
     return L
 
@@ -666,9 +654,7 @@ def solve_L(Y, K, K_g, p, method, m=-1):
             K_g[K_g == 0] = 1.0
             gamma_g = 0
     if epsilon == 1.0:
-        L = (Y / (Z * K**gamma * K_g**gamma_g)) ** (
-            1 / (1 - gamma - gamma_g)
-        )
+        L = (Y / (Z * K**gamma * K_g**gamma_g)) ** (1 / (1 - gamma - gamma_g))
     else:
         L = (
             (

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -493,7 +493,7 @@ def plot_population_path(
     Args:
         age_per_EpS (array_like): list of ages over which to plot
             population distribution
-        pop_2013_pct (array_like): population distribution in 2013
+        initial_pop_pct (array_like): initial year population distribution
         omega_path_lev (Numpy array): number of households by age
             over the transition path
         omega_SSfx (Numpy array): number of households by age
@@ -513,20 +513,20 @@ def plot_population_path(
     plt.plot(age_per_EpS, initial_pop_pct, label=str(data_year) + " pop.")
     plt.plot(
         age_per_EpS,
-        (omega_path_lev[:, 0] / omega_path_lev[:, 0].sum()),
+        (omega_path_lev[0, :] / omega_path_lev[0, :].sum()),
         label=str(curr_year) + " pop.",
     )
     plt.plot(
         age_per_EpS,
         (
-            omega_path_lev[:, int(0.5 * S)]
-            / omega_path_lev[:, int(0.5 * S)].sum()
+            omega_path_lev[int(0.5 * S), :]
+            / omega_path_lev[int(0.5 * S), :].sum()
         ),
         label="T=" + str(int(0.5 * S)) + " pop.",
     )
     plt.plot(
         age_per_EpS,
-        (omega_path_lev[:, int(S)] / omega_path_lev[:, int(S)].sum()),
+        (omega_path_lev[int(S), :] / omega_path_lev[int(S), :].sum()),
         label="T=" + str(int(S)) + " pop.",
     )
     plt.plot(age_per_EpS, omega_SSfx, label="Adj. SS pop.")

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -13,8 +13,9 @@ def plot_imm_rates(
     imm_rates,
     start_year=DEFAULT_START_YEAR,
     years_to_plot=[DEFAULT_START_YEAR],
+    include_title=False,
     source="United Nations, World Population Prospects",
-    output_dir=None,
+    path=None,
 ):
     """
     Plot fertility rates from the data
@@ -25,7 +26,7 @@ def plot_imm_rates(
         start_year (int): first year of data
         years_to_plot (list): list of years to plot
         source (str): data source for fertility rates
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -50,6 +51,8 @@ def plot_imm_rates(
         fontsize=9,
     )
     plt.tight_layout(rect=(0, 0.035, 1, 1))
+    if include_title:
+        plt.title("Immigration Rates")
     # Save or return figure
     if output_dir:
         output_path = os.path.join(output_dir, "imm_rates")
@@ -295,7 +298,7 @@ def plot_fert_rates(
     start_year=DEFAULT_START_YEAR,
     years_to_plot=[DEFAULT_START_YEAR],
     source="United Nations, World Population Prospects",
-    output_dir=None,
+    path=None,
 ):
     """
     Plot fertility rates from the data
@@ -306,7 +309,7 @@ def plot_fert_rates(
         start_year (int): first year of data
         years_to_plot (list): list of years to plot
         source (str): data source for fertility rates
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -346,7 +349,7 @@ def plot_mort_rates_data(
     start_year=DEFAULT_START_YEAR,
     years_to_plot=[DEFAULT_START_YEAR],
     source="United Nations, World Population Prospects",
-    output_dir=None,
+    path=None,
 ):
     """
     Plots mortality rates from the data.
@@ -357,7 +360,7 @@ def plot_mort_rates_data(
         start_year (int): first year of data
         years_to_plot (list): list of years to plot
         source (str): data source for fertility rates
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -393,7 +396,7 @@ def plot_mort_rates_data(
 
 
 def plot_omega_fixed(
-    age_per_EpS, omega_SS_orig, omega_SSfx, E, S, output_dir=None
+    age_per_EpS, omega_SS_orig, omega_SSfx, E, S, path=None
 ):
     """
     Plot the steady-state population distribution implied by the data
@@ -411,7 +414,7 @@ def plot_omega_fixed(
             after adjustment to immigration rates
         E (int): age at which household becomes economically active
         S (int): number of years which household is economically active
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -437,7 +440,7 @@ def plot_omega_fixed(
 
 
 def plot_imm_fixed(
-    age_per_EpS, imm_rates_orig, imm_rates_adj, E, S, output_dir=None
+    age_per_EpS, imm_rates_orig, imm_rates_adj, E, S, path=None
 ):
     """
     Plot the immigration rates implied by the data on population,
@@ -452,7 +455,7 @@ def plot_imm_fixed(
         imm_rates_adj (Numpy array): adjusted immigration rates by age
         E (int): age at which household becomes economically active
         S (int): number of years which household is economically active
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -485,7 +488,7 @@ def plot_population_path(
     data_year,
     curr_year,
     S,
-    output_dir=None,
+    path=None,
 ):
     """
     Plot the distribution of the population over age for various years.
@@ -501,7 +504,7 @@ def plot_population_path(
         data_year (int): year of data for initial_pop_pct
         curr_year (int): current year in the model
         S (int): number of years which household is economically active
-        output_dir (str): path to save figure to, if None then figure
+        path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
@@ -554,7 +557,7 @@ def gen_3Dscatters_hist(df, s, t, output_dir):
             rates
         s (int): age of individual, >= 21
         t (int): year of analysis, >= 2016
-        output_dir (str): output directory for saving plot files
+        path (str): output directory for saving plot files
 
     Returns:
         None
@@ -689,7 +692,7 @@ def txfunc_graph(
         tax_func_type (str): functional form of tax functions
         params_to_plot (array_like or function): tax function parameters or
             nonparametric function
-        output_dir (str): output directory for saving plot files
+        path (str): output directory for saving plot files
 
     Returns:
         None
@@ -804,7 +807,7 @@ def txfunc_sse_plot(age_vec, sse_mat, start_year, varstr, output_dir, round):
             size is BW x S
         start_year (int): first year of budget window
         varstr (str): name of tax function being evaluated
-        output_dir (str): path to save graph to
+        path (str): path to save graph to
         round (int): which round of sweeping for outliers (0, 1, or 2)
 
     Returns:
@@ -833,7 +836,7 @@ def txfunc_sse_plot(age_vec, sse_mat, start_year, varstr, output_dir, round):
 
 
 def plot_income_data(
-    ages, abil_midp, abil_pcts, emat, t=None, output_dir=None, filesuffix=""
+    ages, abil_midp, abil_pcts, emat, t=None, path=None, filesuffix=""
 ):
     """
     This function graphs ability matrix in 3D, 2D, log, and nolog

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -513,10 +513,20 @@ def plot_population_path(
 
     """
     fig, ax = plt.subplots()
-    plt.plot(age_per_EpS, (omega_path_lev[start_year - year1, :] / omega_path_lev[start_year - year1, :].sum()), label=str(year1) + " pop.")
     plt.plot(
         age_per_EpS,
-        (omega_path_lev[start_year - year2, :] / omega_path_lev[start_year - year2, :].sum()),
+        (
+            omega_path_lev[start_year - year1, :]
+            / omega_path_lev[start_year - year1, :].sum()
+        ),
+        label=str(year1) + " pop.",
+    )
+    plt.plot(
+        age_per_EpS,
+        (
+            omega_path_lev[start_year - year2, :]
+            / omega_path_lev[start_year - year2, :].sum()
+        ),
         label=str(year2) + " pop.",
     )
     plt.plot(

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -54,8 +54,8 @@ def plot_imm_rates(
     if include_title:
         plt.title("Immigration Rates")
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "imm_rates")
+    if path:
+        output_path = os.path.join(path, "imm_rates")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -335,8 +335,8 @@ def plot_fert_rates(
     )
     plt.tight_layout(rect=(0, 0.035, 1, 1))
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "fert_rates")
+    if path:
+        output_path = os.path.join(path, "fert_rates")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -386,8 +386,8 @@ def plot_mort_rates_data(
     )
     plt.tight_layout(rect=(0, 0.035, 1, 1))
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "mort_rates")
+    if path:
+        output_path = os.path.join(path, "mort_rates")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -431,8 +431,8 @@ def plot_omega_fixed(
     plt.xlim((0, E + S + 1))
     plt.legend(loc="upper right")
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "OrigVsFixSSpop")
+    if path:
+        output_path = os.path.join(path, "OrigVsFixSSpop")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -472,8 +472,8 @@ def plot_imm_fixed(
     plt.xlim((0, E + S + 1))
     plt.legend(loc="upper center")
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "OrigVsAdjImm")
+    if path:
+        output_path = os.path.join(path, "OrigVsAdjImm")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -538,8 +538,8 @@ def plot_population_path(
     plt.ylabel(r"Pop. dist'n $\omega_{s}$")
     plt.legend(loc="lower left")
     # Save or return figure
-    if output_dir:
-        output_path = os.path.join(output_dir, "PopDistPath")
+    if path:
+        output_path = os.path.join(path, "PopDistPath")
         plt.savefig(output_path, dpi=300)
         plt.close()
     else:
@@ -861,15 +861,15 @@ def plot_income_data(
     J = abil_midp.shape[0]
     abil_mesh, age_mesh = np.meshgrid(abil_midp, ages)
     cmap1 = matplotlib.cm.get_cmap("summer")
-    if output_dir:
+    if path:
         # Make sure that directory is created
-        utils.mkdirs(output_dir)
+        utils.mkdirs(path)
         if J == 1:
             # Plot of 2D, J=1 in levels
             plt.figure()
             plt.plot(ages, emat[t, :, :])
             filename = "ability_2D_lev" + filesuffix
-            fullpath = os.path.join(output_dir, filename)
+            fullpath = os.path.join(path, filename)
             plt.savefig(fullpath, dpi=300)
             plt.close()
 
@@ -877,7 +877,7 @@ def plot_income_data(
             plt.figure()
             plt.plot(ages, np.log(emat[t, :, :]))
             filename = "ability_2D_log" + filesuffix
-            fullpath = os.path.join(output_dir, filename)
+            fullpath = os.path.join(path, filename)
             plt.savefig(fullpath, dpi=300)
             plt.close()
         else:
@@ -895,7 +895,7 @@ def plot_income_data(
             ax10.set_ylabel(r"ability type -$j$")
             ax10.set_zlabel(r"ability $e_{j,s}$")
             filename = "ability_3D_lev" + filesuffix
-            fullpath = os.path.join(output_dir, filename)
+            fullpath = os.path.join(path, filename)
             plt.savefig(fullpath, dpi=300)
             plt.close()
 
@@ -913,7 +913,7 @@ def plot_income_data(
             ax11.set_ylabel(r"ability type -$j$")
             ax11.set_zlabel(r"log ability $log(e_{j,s})$")
             filename = "ability_3D_log" + filesuffix
-            fullpath = os.path.join(output_dir, filename)
+            fullpath = os.path.join(path, filename)
             plt.savefig(fullpath, dpi=300)
             plt.close()
 
@@ -961,7 +961,7 @@ def plot_income_data(
                 ax.set_xlabel(r"age-$s$")
                 ax.set_ylabel(r"log ability $log(e_{j,s})$")
                 filename = "ability_2D_log" + filesuffix
-                fullpath = os.path.join(output_dir, filename)
+                fullpath = os.path.join(path, filename)
                 plt.savefig(fullpath, dpi=300)
                 plt.close()
     else:

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -43,7 +43,7 @@ def plot_imm_rates(
     #     fontsize=20)
     plt.xlabel(r"Age $s$")
     plt.ylabel(r"Immigration rate $i_{s}$")
-    plt.legend(loc="upper right")
+    plt.legend(loc="upper left")
     plt.text(
         -5,
         -0.023,
@@ -480,11 +480,11 @@ def plot_imm_fixed(
 
 def plot_population_path(
     age_per_EpS,
-    initial_pop_pct,
     omega_path_lev,
     omega_SSfx,
-    data_year,
-    curr_year,
+    start_year,
+    year1,
+    year2,
     S,
     path=None,
 ):
@@ -499,8 +499,10 @@ def plot_population_path(
             over the transition path
         omega_SSfx (Numpy array): number of households by age
             in the SS
-        data_year (int): year of data for initial_pop_pct
-        curr_year (int): current year in the model
+        start_year (int): first year of data (so can get index of year1
+            and year2)
+        year1 (int): first year of data to plot
+        year2 (int): second year of data to plot
         S (int): number of years which household is economically active
         path (str): path to save figure to, if None then figure
             is returned
@@ -511,11 +513,11 @@ def plot_population_path(
 
     """
     fig, ax = plt.subplots()
-    plt.plot(age_per_EpS, initial_pop_pct, label=str(data_year) + " pop.")
+    plt.plot(age_per_EpS, (omega_path_lev[start_year - year1, :] / omega_path_lev[start_year - year1, :].sum()), label=str(year1) + " pop.")
     plt.plot(
         age_per_EpS,
-        (omega_path_lev[0, :] / omega_path_lev[0, :].sum()),
-        label=str(curr_year) + " pop.",
+        (omega_path_lev[start_year - year2, :] / omega_path_lev[start_year - year2, :].sum()),
+        label=str(year2) + " pop.",
     )
     plt.plot(
         age_per_EpS,

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -9,36 +9,55 @@ from ogcore import utils, txfunc
 from ogcore.constants import DEFAULT_START_YEAR, VAR_LABELS
 
 
-def plot_imm_rates(p, year=DEFAULT_START_YEAR, include_title=False, path=None):
+def plot_imm_rates(
+    imm_rates,
+    start_year=DEFAULT_START_YEAR,
+    years_to_plot=[DEFAULT_START_YEAR],
+    source="United Nations, World Population Prospects",
+    output_dir=None,
+):
     """
-    Create a plot of immigration rates from OG-Core parameterization.
+    Plot fertility rates from the data
 
     Args:
-        p (OG-Core Specifications class): parameters object
-        year (integer): year of mortality ratese to plot
-        include_title (bool): whether to include a title in the plot
-        path (string): path to save figure to
+        imm_rates (NumPy array): immigration rates for each of
+            totpers
+        start_year (int): first year of data
+        years_to_plot (list): list of years to plot
+        source (str): data source for fertility rates
+        output_dir (str): path to save figure to, if None then figure
+            is returned
 
     Returns:
-        fig (Matplotlib plot object): plot of immigration rates
+        fig (Matplotlib plot object): plot of fertility rates
 
     """
-    assert isinstance(year, int)
-    age_per = np.linspace(p.E, p.E + p.S, p.S)
+    # create line styles to cycle through
+    plt.rc("axes", prop_cycle=(cycler("linestyle", [":", "-.", "-", "--"])))
     fig, ax = plt.subplots()
-    plt.scatter(age_per, p.imm_rates[year - p.start_year, :], s=40, marker="d")
-    plt.plot(age_per, p.imm_rates[year - p.start_year, :])
-    plt.xlabel(r"Age $s$ (model periods)")
-    plt.ylabel(r"Imm. rate $i_{s}$")
-    vals = ax.get_yticks()
-    ax.set_yticklabels(["{:,.2%}".format(x) for x in vals])
-    if include_title:
-        plt.title("Immigration Rates in " + str(year))
-    if path is None:
-        return fig
+    for y in years_to_plot:
+        i = start_year - y
+        plt.plot(imm_rates[i, :], c="blue", label="Year " + str(y))
+    # plt.title('Fertility rates by age ($f_{s}$)',
+    #     fontsize=20)
+    plt.xlabel(r"Age $s$")
+    plt.ylabel(r"Immigration rate $i_{s}$")
+    plt.legend(loc="upper right")
+    plt.text(
+        -5,
+        -0.023,
+        "Source: " + source,
+        fontsize=9,
+    )
+    plt.tight_layout(rect=(0, 0.035, 1, 1))
+    # Save or return figure
+    if output_dir:
+        output_path = os.path.join(output_dir, "imm_rates")
+        plt.savefig(output_path, dpi=300)
+        plt.close()
     else:
-        fig_path = os.path.join(path, "imm_rates_orig")
-        plt.savefig(fig_path, dpi=300)
+        fig.show()
+        return fig
 
 
 def plot_mort_rates(
@@ -272,9 +291,6 @@ def plot_fert_rates(
     fert_rates,
     start_year=DEFAULT_START_YEAR,
     years_to_plot=[DEFAULT_START_YEAR],
-    totpers=100,
-    min_yr=0,
-    max_yr=100,
     source="United Nations, World Population Prospects",
     output_dir=None,
 ):
@@ -286,10 +302,6 @@ def plot_fert_rates(
             totpers
         start_year (int): first year of data
         years_to_plot (list): list of years to plot
-        totpers (int): total number of agent life periods (E+S), >= 3
-        min_yr (int): age in years at which agents are born, >= 0
-        max_yr (int): age in years at which agents die with certainty,
-            >= 4
         source (str): data source for fertility rates
         output_dir (str): path to save figure to, if None then figure
             is returned
@@ -299,7 +311,7 @@ def plot_fert_rates(
 
     """
     # create line styles to cycle through
-    plt.rc('axes', prop_cycle=(cycler('linestyle', [':', '-.', '-', '--'])))
+    plt.rc("axes", prop_cycle=(cycler("linestyle", [":", "-.", "-", "--"])))
     fig, ax = plt.subplots()
     for y in years_to_plot:
         i = start_year - y
@@ -330,9 +342,6 @@ def plot_mort_rates_data(
     mort_rates,
     start_year=DEFAULT_START_YEAR,
     years_to_plot=[DEFAULT_START_YEAR],
-    totpers=100,
-    min_yr=0,
-    max_yr=100,
     source="United Nations, World Population Prospects",
     output_dir=None,
 ):
@@ -340,16 +349,11 @@ def plot_mort_rates_data(
     Plots mortality rates from the data.
 
     Args:
-        totpers (int): total number of agent life periods (E+S), >= 3
-        min_yr (int): age in years at which agents are born, >= 0
-        max_yr (int): age in years at which agents die with certainty,
-            >= 4
-        age_year_all (array_like): ages in mortality rate data
-        mort_rates_all (array_like): mortality rates by age from data,
-            average across males and females
-        infmort_rate (scalar): infant mortality rate
-        mort_rates (array_like): fitted mortality rates for each of
+        mort_rates (array_like): mortality rates for each of
             totpers
+        start_year (int): first year of data
+        years_to_plot (list): list of years to plot
+        source (str): data source for fertility rates
         output_dir (str): path to save figure to, if None then figure
             is returned
 
@@ -358,7 +362,7 @@ def plot_mort_rates_data(
 
     """
     # create line styles to cycle through
-    plt.rc('axes', prop_cycle=(cycler('linestyle', [':', '-.', '-', '--'])))
+    plt.rc("axes", prop_cycle=(cycler("linestyle", [":", "-.", "-", "--"])))
     fig, ax = plt.subplots()
     for y in years_to_plot:
         i = start_year - y

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -395,9 +395,7 @@ def plot_mort_rates_data(
         return fig
 
 
-def plot_omega_fixed(
-    age_per_EpS, omega_SS_orig, omega_SSfx, E, S, path=None
-):
+def plot_omega_fixed(age_per_EpS, omega_SS_orig, omega_SSfx, E, S, path=None):
     """
     Plot the steady-state population distribution implied by the data
     on fertility and mortality rates versus the the steady-state

--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -8,6 +8,7 @@ particular year (t). x is total labor income, and y is total capital
 income.
 ------------------------------------------------------------------------
 """
+
 # Import packages
 import time
 import os
@@ -1307,15 +1308,15 @@ def tax_func_loop(
                     (NoData_cnt, 1)
                 ) * (x1_mtry - x0_mtry)
                 for s_ind in range(NoData_cnt):
-                    etrparam_list[
-                        s - NoData_cnt - min_age + s_ind
-                    ] = lin_int_etr[s_ind, :]
-                    mtrxparam_list[
-                        s - NoData_cnt - min_age + s_ind
-                    ] = lin_int_mtrx[s_ind, :]
-                    mtryparam_list[
-                        s - NoData_cnt - min_age + s_ind
-                    ] = lin_int_mtry[s_ind, :]
+                    etrparam_list[s - NoData_cnt - min_age + s_ind] = (
+                        lin_int_etr[s_ind, :]
+                    )
+                    mtrxparam_list[s - NoData_cnt - min_age + s_ind] = (
+                        lin_int_mtrx[s_ind, :]
+                    )
+                    mtryparam_list[s - NoData_cnt - min_age + s_ind] = (
+                        lin_int_mtry[s_ind, :]
+                    )
 
             elif (
                 (NoData_cnt > 0)

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -11,6 +11,8 @@ import pandas as pd
 import pickle
 from pkg_resources import resource_stream, Requirement
 import importlib.resources
+import urllib3
+import ssl
 
 EPSILON = 1e-10  # tolerance or comparison functions
 
@@ -1046,3 +1048,32 @@ def extrapolate_arrays(param_in, dims=None, item="Parameter Name"):
             )
 
     return param_out
+
+
+class CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    """
+    The UN Data Portal server doesn't support "RFC 5746 secure renegotiation". This causes and error when the client is using OpenSSL 3, which enforces that standard by default.
+    The fix is to create a custom SSL context that allows for legacy connections. This defines a function get_legacy_session() that should be used instead of requests().
+    """
+
+    # "Transport adapter" that allows us to use custom ssl_context.
+    def __init__(self, ssl_context=None, **kwargs):
+        self.ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = urllib3.poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
+
+
+def get_legacy_session():
+    ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT  #in Python 3.12 you will be able to switch from 0x4 to ssl.OP_LEGACY_SERVER_CONNECT.
+    session = requests.session()
+    session.mount("https://", CustomHttpAdapter(ctx))
+    return session
+

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -1076,4 +1076,3 @@ def get_legacy_session():
     session = requests.session()
     session.mount("https://", CustomHttpAdapter(ctx))
     return session
-

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -46,13 +46,15 @@ def test_pop_smooth():
     # in that period
     assert np.all(
         np.abs(
-            pop_dict["omega"][:fixper-2, :] - pop_dict["omega"][1:fixper -1, :]
+            pop_dict["omega"][: fixper - 2, :]
+            - pop_dict["omega"][1 : fixper - 1, :]
         )
         < 0.003
     )
     assert np.all(
         np.abs(
-            pop_dict["omega"][fixper:-1, :] - pop_dict["omega"][fixper+1:, :]
+            pop_dict["omega"][fixper:-1, :]
+            - pop_dict["omega"][fixper + 1 :, :]
         )
         < 0.0001
     )
@@ -84,15 +86,11 @@ def test_pop_growth_smooth():
     # to achieve the SS more quickly so the min dist is not super small
     # in that period
     assert np.all(
-        np.abs(
-            pop_dict["g_n"][:fixper-2] - pop_dict["g_n"][1:fixper -1]
-        )
+        np.abs(pop_dict["g_n"][: fixper - 2] - pop_dict["g_n"][1 : fixper - 1])
         < 0.003
     )
     assert np.all(
-        np.abs(
-            pop_dict["g_n"][fixper:-1] - pop_dict["g_n"][fixper+1:]
-        )
+        np.abs(pop_dict["g_n"][fixper:-1] - pop_dict["g_n"][fixper + 1 :])
         < 0.003
     )
 
@@ -115,13 +113,15 @@ def test_imm_smooth():
     # in that period
     assert np.all(
         np.abs(
-            pop_dict["imm_rates"][:fixper-2, :] - pop_dict["imm_rates"][1:fixper -1, :]
+            pop_dict["imm_rates"][: fixper - 2, :]
+            - pop_dict["imm_rates"][1 : fixper - 1, :]
         )
         < 0.0001
     )
     assert np.all(
         np.abs(
-            pop_dict["imm_rates"][fixper:-1, :] - pop_dict["imm_rates"][fixper+1:, :]
+            pop_dict["imm_rates"][fixper:-1, :]
+            - pop_dict["imm_rates"][fixper + 1 :, :]
         )
         < 0.0001
     )

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -112,15 +112,21 @@ def test_imm_smooth():
     # note that in the "fixper" we impost a jump in immigration rates
     # to achieve the SS more quickly so the min dist is not super small
     # in that period
-    print("Max diff before = ", np.abs(
+    print(
+        "Max diff before = ",
+        np.abs(
             pop_dict["imm_rates"][: fixper - 2, :]
             - pop_dict["imm_rates"][1 : fixper - 1, :]
-        ).max())
+        ).max(),
+    )
 
-    print("Max diff after = ", np.abs(
+    print(
+        "Max diff after = ",
+        np.abs(
             pop_dict["imm_rates"][fixper:-1, :]
             - pop_dict["imm_rates"][fixper + 1 :, :]
-        ).max())
+        ).max(),
+    )
     assert np.all(
         np.abs(
             pop_dict["imm_rates"][: fixper - 2, :]
@@ -131,7 +137,7 @@ def test_imm_smooth():
     assert np.all(
         np.abs(
             pop_dict["imm_rates"][fixper:-1, :]
-            - pop_dict["imm_rates"][fixper + 1:, :]
+            - pop_dict["imm_rates"][fixper + 1 :, :]
         )
         < 0.00001
     )
@@ -217,17 +223,45 @@ def test_custom_series_all():
     S = 80
     T = int(round(4.0 * S))
     start_year = 2019
-    fert_rates = demographics.get_fert(E + S, 0, 99, start_year=start_year, end_year=start_year+1, graph=False)
-    mort_rates, infmort_rates = demographics.get_mort(E+ S, 0, 99, start_year=start_year, end_year=start_year+1, graph=False)
-    imm_rates = demographics.get_imm_rates(E+S, 0, 99, fert_rates=fert_rates, mort_rates=mort_rates, infmort_rates=infmort_rates, start_year=start_year, end_year=start_year+1, graph=False)
-    pop_dist = np.zeros((2, E+S))
+    fert_rates = demographics.get_fert(
+        E + S,
+        0,
+        99,
+        start_year=start_year,
+        end_year=start_year + 1,
+        graph=False,
+    )
+    mort_rates, infmort_rates = demographics.get_mort(
+        E + S,
+        0,
+        99,
+        start_year=start_year,
+        end_year=start_year + 1,
+        graph=False,
+    )
+    imm_rates = demographics.get_imm_rates(
+        E + S,
+        0,
+        99,
+        fert_rates=fert_rates,
+        mort_rates=mort_rates,
+        infmort_rates=infmort_rates,
+        start_year=start_year,
+        end_year=start_year + 1,
+        graph=False,
+    )
+    pop_dist = np.zeros((2, E + S))
     for t in range(pop_dist.shape[0]):
-        df = demographics.get_un_data("47", start_year=start_year + t, end_year=start_year + t)
+        df = demographics.get_un_data(
+            "47", start_year=start_year + t, end_year=start_year + t
+        )
         pop = df[(df.age < 100) & (df.age >= 0)].value.values
-        pop_dist[t, :] = demographics.pop_rebin(pop, E+S)
-    df = demographics.get_un_data("47", start_year=start_year-1, end_year=start_year-1)
+        pop_dist[t, :] = demographics.pop_rebin(pop, E + S)
+    df = demographics.get_un_data(
+        "47", start_year=start_year - 1, end_year=start_year - 1
+    )
     pop = df[(df.age < 100) & (df.age >= 0)].value.values
-    pre_pop_dist = demographics.pop_rebin(pop, E+S)
+    pre_pop_dist = demographics.pop_rebin(pop, E + S)
     pop_dict = demographics.get_pop_objs(
         E,
         S,
@@ -260,17 +294,35 @@ def test_custom_series_fail():
         S = 80
         T = int(round(4.0 * S))
         start_year = 2019
-        fert_rates = demographics.get_fert(E + S, 0, 99, start_year=start_year, end_year=start_year+1, graph=False)
-        mort_rates, infmort_rates = demographics.get_mort(E+ S, 0, 99, start_year=start_year, end_year=start_year+1, graph=False)
+        fert_rates = demographics.get_fert(
+            E + S,
+            0,
+            99,
+            start_year=start_year,
+            end_year=start_year + 1,
+            graph=False,
+        )
+        mort_rates, infmort_rates = demographics.get_mort(
+            E + S,
+            0,
+            99,
+            start_year=start_year,
+            end_year=start_year + 1,
+            graph=False,
+        )
         imm_rates = np.ones((2, E + S)) * 0.01
-        pop_dist = np.zeros((2, E+S))
+        pop_dist = np.zeros((2, E + S))
         for t in range(pop_dist.shape[0]):
-            df = demographics.get_un_data("47", start_year=start_year + t, end_year=start_year + t)
+            df = demographics.get_un_data(
+                "47", start_year=start_year + t, end_year=start_year + t
+            )
             pop = df[(df.age < 100) & (df.age >= 0)].value.values
-            pop_dist[t, :] = demographics.pop_rebin(pop, E+S)
-        df = demographics.get_un_data("47", start_year=start_year-1, end_year=start_year-1)
+            pop_dist[t, :] = demographics.pop_rebin(pop, E + S)
+        df = demographics.get_un_data(
+            "47", start_year=start_year - 1, end_year=start_year - 1
+        )
         pop = df[(df.age < 100) & (df.age >= 0)].value.values
-        pre_pop_dist = demographics.pop_rebin(pop, E+S)
+        pre_pop_dist = demographics.pop_rebin(pop, E + S)
         pop_dict = demographics.get_pop_objs(
             E,
             S,
@@ -287,6 +339,7 @@ def test_custom_series_fail():
             pre_pop_dist=pre_pop_dist,
             GraphDiag=False,
         )
+
 
 # Test that SS solved for
 def test_SS_dist():

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -14,7 +14,14 @@ def test_get_pop_objs():
     start_year = 2019
 
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
+        E,
+        S,
+        T,
+        0,
+        99,
+        initial_data_year=start_year - 1,
+        final_data_year=start_year,
+        GraphDiag=False,
     )
 
     assert np.allclose(pop_dict["omega_SS"], pop_dict["omega"][-1, :])
@@ -35,8 +42,8 @@ def test_pop_smooth():
         T,
         0,
         99,
-        start_year - 1,
-        start_year,
+        initial_data_year=start_year - 1,
+        final_data_year=start_year,
         country_id="840",
         GraphDiag=False,
     )
@@ -76,8 +83,8 @@ def test_pop_growth_smooth():
         T,
         0,
         99,
-        start_year - 1,
-        start_year,
+        initial_data_year=start_year - 1,
+        final_data_year=start_year,
         country_id="840",
         GraphDiag=False,
     )
@@ -86,6 +93,7 @@ def test_pop_growth_smooth():
     # note that in the "fixper" we impost a jump in immigration rates
     # to achieve the SS more quickly so the min dist is not super small
     # in that period
+    print("first few of g_n = ", pop_dict["g_n"][:5])
     assert np.all(
         np.abs(pop_dict["g_n"][: fixper - 2] - pop_dict["g_n"][1 : fixper - 1])
         < 0.003
@@ -106,7 +114,14 @@ def test_imm_smooth():
     start_year = 2019
     fixper = int(1.5 * S + 2)
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
+        E,
+        S,
+        T,
+        0,
+        99,
+        initial_data_year=start_year - 1,
+        final_data_year=start_year,
+        GraphDiag=False,
     )
     # assert diffs are small
     # note that in the "fixper" we impost a jump in immigration rates
@@ -206,8 +221,8 @@ def test_custom_series():
         T,
         0,
         99,
-        start_year,
-        start_year + 1,
+        initial_data_year=start_year,
+        final_data_year=start_year + 1,
         GraphDiag=False,
         imm_rates=imm_rates,
     )
@@ -250,7 +265,7 @@ def test_custom_series_all():
         end_year=start_year + 1,
         graph=False,
     )
-    pop_dist = np.zeros((2, E + S))
+    pop_dist = np.zeros((3, E + S))
     for t in range(pop_dist.shape[0]):
         df = demographics.get_un_data(
             "47", start_year=start_year + t, end_year=start_year + t
@@ -268,14 +283,14 @@ def test_custom_series_all():
         T,
         0,
         99,
-        initial_data_year=start_year,
-        final_data_year=start_year + 1,
         fert_rates=fert_rates,
         mort_rates=mort_rates,
         infmort_rates=infmort_rates,
         imm_rates=imm_rates,
         pop_dist=pop_dist,
         pre_pop_dist=pre_pop_dist,
+        initial_data_year=start_year,
+        final_data_year=start_year + 1,
         GraphDiag=False,
     )
     assert pop_dict is not None
@@ -329,14 +344,14 @@ def test_custom_series_fail():
             T,
             0,
             99,
-            initial_data_year=start_year,
-            final_data_year=start_year + 1,
             fert_rates=fert_rates,
             mort_rates=mort_rates,
             infmort_rates=infmort_rates,
             imm_rates=imm_rates,
             pop_dist=pop_dist,
             pre_pop_dist=pre_pop_dist,
+            initial_data_year=start_year,
+            final_data_year=start_year + 1,
             GraphDiag=False,
         )
 
@@ -353,7 +368,14 @@ def test_SS_dist():
     start_year = 2019
 
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
+        E,
+        S,
+        T,
+        0,
+        99,
+        initial_data_year=start_year - 1,
+        final_data_year=start_year,
+        GraphDiag=False,
     )
     # Assert that S reached by period T
     assert np.allclose(pop_dict["omega_SS"], pop_dict["omega"][-S, :])

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ogusa import demographics
+from ogcore import demographics
 
 
 def test_get_pop_objs():

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -183,7 +183,7 @@ def test_custom_series():
     S = 80
     T = int(round(4.0 * S))
     start_year = 2019
-    fert_rates = np.ones((1, S)) * 0.01
+    imm_rates = np.ones((1, E + S)) * 0.01
     pop_dict = demographics.get_pop_objs(
         E,
         S,
@@ -193,9 +193,10 @@ def test_custom_series():
         start_year - 1,
         start_year,
         GraphDiag=False,
-        fert_rates=fert_rates,
+        imm_rates=imm_rates,
     )
-    assert np.allclose(pop_dict["fert_rates"][0, :], fert_rates)
+    assert np.allclose(pop_dict["imm_rates"][0, :], imm_rates[0, E:])
+
 
 # Test that SS solved for
 def test_SS_dist():

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -116,7 +116,7 @@ def test_imm_smooth():
             pop_dict["imm_rates"][: fixper - 2, :]
             - pop_dict["imm_rates"][1 : fixper - 1, :]
         )
-        < 0.0001
+        < 0.03
     )
     assert np.all(
         np.abs(

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -103,7 +103,7 @@ def test_imm_smooth():
     S = 80
     T = int(round(4.0 * S))
     start_year = 2019
-    fixper = int(1.5 * S)
+    fixper = int(1.5 * S + 2)
     pop_dict = demographics.get_pop_objs(
         E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
     )
@@ -111,6 +111,15 @@ def test_imm_smooth():
     # note that in the "fixper" we impost a jump in immigration rates
     # to achieve the SS more quickly so the min dist is not super small
     # in that period
+    print("Max diff before = ", np.abs(
+            pop_dict["imm_rates"][: fixper - 2, :]
+            - pop_dict["imm_rates"][1 : fixper - 1, :]
+        ).max())
+
+    print("Max diff after = ", np.abs(
+            pop_dict["imm_rates"][fixper:-1, :]
+            - pop_dict["imm_rates"][fixper + 1 :, :]
+        ).max())
     assert np.all(
         np.abs(
             pop_dict["imm_rates"][: fixper - 2, :]
@@ -121,9 +130,9 @@ def test_imm_smooth():
     assert np.all(
         np.abs(
             pop_dict["imm_rates"][fixper:-1, :]
-            - pop_dict["imm_rates"][fixper + 1 :, :]
+            - pop_dict["imm_rates"][fixper + 1:, :]
         )
-        < 0.0001
+        < 0.00001
     )
 
 
@@ -183,15 +192,15 @@ def test_custom_series():
     S = 80
     T = int(round(4.0 * S))
     start_year = 2019
-    imm_rates = np.ones((1, E + S)) * 0.01
+    imm_rates = np.ones((2, E + S)) * 0.01
     pop_dict = demographics.get_pop_objs(
         E,
         S,
         T,
         0,
         99,
-        start_year - 1,
         start_year,
+        start_year + 1,
         GraphDiag=False,
         imm_rates=imm_rates,
     )

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -13,7 +13,7 @@ def test_get_pop_objs():
     start_year = 2019
 
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 1, 100, start_year - 1, start_year, GraphDiag=False
+        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
     )
 
     assert np.allclose(pop_dict["omega_SS"], pop_dict["omega"][-1, :])
@@ -32,8 +32,8 @@ def test_pop_smooth():
         E,
         S,
         T,
-        1,
-        100,
+        0,
+        99,
         start_year - 1,
         start_year,
         country_id="840",
@@ -73,8 +73,8 @@ def test_pop_growth_smooth():
         E,
         S,
         T,
-        1,
-        100,
+        0,
+        99,
         start_year - 1,
         start_year,
         country_id="840",
@@ -105,7 +105,7 @@ def test_imm_smooth():
     start_year = 2019
     fixper = int(1.5 * S)
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 1, 100, start_year - 1, start_year, GraphDiag=False
+        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
     )
     # assert diffs are small
     # note that in the "fixper" we impost a jump in immigration rates
@@ -132,7 +132,7 @@ def test_get_fert():
     Test of function to get fertility rates from data
     """
     S = 100
-    fert_rates = demographics.get_fert(S, 0, 100, graph=False)
+    fert_rates = demographics.get_fert(S, 0, 99, graph=False)
     assert fert_rates.shape[1] == S
 
 
@@ -141,7 +141,7 @@ def test_get_mort():
     Test of function to get mortality rates from data
     """
     S = 100
-    mort_rates, infmort_rate = demographics.get_mort(S, 0, 100, graph=False)
+    mort_rates, infmort_rate = demographics.get_mort(S, 0, 99, graph=False)
     assert mort_rates.shape[1] == S
 
 
@@ -149,7 +149,7 @@ def test_infant_mort():
     """
     Test of function to get mortality rates from data
     """
-    mort_rates, infmort_rate = demographics.get_mort(100, 0, 100, graph=False)
+    mort_rates, infmort_rate = demographics.get_mort(100, 0, 99, graph=False)
     # check that infant mortality equals rate hardcoded into
     # demographics.py
     assert infmort_rate == 0.00491958
@@ -170,7 +170,7 @@ def test_get_imm_rates():
     Test of function to solve for immigration rates from population data
     """
     S = 100
-    imm_rates = demographics.get_imm_rates(S, 0, 100)
+    imm_rates = demographics.get_imm_rates(S, 0, 99)
     assert imm_rates.shape[1] == S
 
 
@@ -188,8 +188,8 @@ def test_custom_series():
         E,
         S,
         T,
-        1,
-        100,
+        0,
+        99,
         start_year - 1,
         start_year,
         GraphDiag=False,
@@ -210,7 +210,7 @@ def test_SS_dist():
     start_year = 2019
 
     pop_dict = demographics.get_pop_objs(
-        E, S, T, 1, 100, start_year - 1, start_year, GraphDiag=False
+        E, S, T, 0, 99, start_year - 1, start_year, GraphDiag=False
     )
     # Assert that S reached by period T
     assert np.allclose(pop_dict["omega_SS"], pop_dict["omega"][-S, :])

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -76,7 +76,7 @@ def test_get_fert():
     """
     S = 100
     fert_rates = demographics.get_fert(S, 0, 100, graph=False)
-    assert fert_rates.shape[0] == S
+    assert fert_rates.shape[1] == S
 
 
 def test_get_mort():
@@ -85,7 +85,7 @@ def test_get_mort():
     """
     S = 100
     mort_rates, infmort_rate = demographics.get_mort(S, 0, 100, graph=False)
-    assert mort_rates.shape[0] == S
+    assert mort_rates.shape[1] == S
 
 
 def test_infant_mort():
@@ -114,4 +114,4 @@ def test_get_imm_rates():
     """
     S = 100
     imm_rates = demographics.get_imm_rates(S, 0, 100)
-    assert imm_rates.shape[0] == S
+    assert imm_rates.shape[1] == S

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,0 +1,117 @@
+import numpy as np
+from ogusa import demographics
+
+
+def test_get_pop_objs():
+    """
+    Test of the that omega_SS and the last period of omega_path_S are
+    close to each other.
+    """
+    E = 20
+    S = 80
+    T = int(round(4.0 * S))
+    start_year = 2019
+
+    pop_dict = demographics.get_pop_objs(
+        E, S, T, 1, 100, start_year - 1, start_year, GraphDiag=False
+    )
+
+    assert np.allclose(pop_dict["omega_SS"], pop_dict["omega"][-1, :])
+
+
+def test_pop_smooth():
+    """
+    Test that population growth rates evolve smoothly.
+    """
+    E = 20
+    S = 80
+    T = int(round(4.0 * S))
+    start_year = 2019
+
+    pop_dict = demographics.get_pop_objs(
+        E,
+        S,
+        T,
+        1,
+        100,
+        start_year - 1,
+        start_year,
+        country_id="840",
+        GraphDiag=False,
+    )
+
+    assert np.any(
+        np.absolute(pop_dict["omega"][:-1, :] - pop_dict["omega"][1:, :])
+        < 0.0001
+    )
+    assert np.any(
+        np.absolute(pop_dict["g_n"][:-1] - pop_dict["g_n"][1:]) < 0.0001
+    )
+
+
+def test_imm_smooth():
+    """
+    Test that population growth rates evolve smoothly.
+    """
+    E = 20
+    S = 80
+    T = int(round(4.0 * S))
+    start_year = 2019
+
+    pop_dict = demographics.get_pop_objs(
+        E, S, T, 1, 100, start_year - 1, start_year, GraphDiag=False
+    )
+
+    assert np.any(
+        np.absolute(
+            pop_dict["imm_rates"][:-1, :] - pop_dict["imm_rates"][1:, :]
+        )
+        < 0.0001
+    )
+
+
+def test_get_fert():
+    """
+    Test of function to get fertility rates from data
+    """
+    S = 100
+    fert_rates = demographics.get_fert(S, 0, 100, graph=False)
+    assert fert_rates.shape[0] == S
+
+
+def test_get_mort():
+    """
+    Test of function to get mortality rates from data
+    """
+    S = 100
+    mort_rates, infmort_rate = demographics.get_mort(S, 0, 100, graph=False)
+    assert mort_rates.shape[0] == S
+
+
+def test_infant_mort():
+    """
+    Test of function to get mortality rates from data
+    """
+    mort_rates, infmort_rate = demographics.get_mort(100, 0, 100, graph=False)
+    # check that infant mortality equals rate hardcoded into
+    # demographics.py
+    assert infmort_rate == 0.00491958
+
+
+def test_pop_rebin():
+    """
+    Test of population rebin function
+    """
+    curr_pop_dist = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+    totpers_new = 5
+    rebinned_data = demographics.pop_rebin(curr_pop_dist, totpers_new)
+    assert rebinned_data.shape[0] == totpers_new
+
+
+def test_get_imm_rates():
+    """
+    Test of function to solve for immigration rates from population data
+    """
+    S = 100
+    imm_rates = demographics.get_imm_rates(S, 0, 100)
+    assert imm_rates.shape[0] == S

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -308,31 +308,29 @@ def test_plot_population_path():
     curr_year = base_params.start_year
     fig = parameter_plots.plot_population_path(
         age_per_EpS,
-        initial_pop_pct,
         omega_path_lev,
         omega_SSfx,
         data_year,
         curr_year,
+        curr_year + 5,
         S,
     )
     assert fig
 
 
 def test_plot_population_path_save_fig(tmpdir):
-    E = 0
     S = base_params.S
     age_per_EpS = np.arange(21, S + 21)
-    pop_2013_pct = base_params.omega[0, :]
     omega_path_lev = base_params.omega
     omega_SSfx = base_params.omega_SS
     curr_year = base_params.start_year
     parameter_plots.plot_population_path(
         age_per_EpS,
-        pop_2013_pct,
         omega_path_lev,
         omega_SSfx,
         curr_year,
-        E,
+        curr_year + 3,
+        curr_year + 50,
         S,
         path=tmpdir,
     )

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -44,13 +44,13 @@ base_params.rho = np.tile(
 
 
 def test_plot_imm_rates():
-    fig = parameter_plots.plot_imm_rates(base_params, include_title=True)
+    fig = parameter_plots.plot_imm_rates(base_params.imm_rates, base_params.start_year, [base_params.start_year], include_title=True)
     assert fig
 
 
 def test_plot_imm_rates_save_fig(tmpdir):
-    parameter_plots.plot_imm_rates(base_params, path=tmpdir)
-    img = mpimg.imread(os.path.join(tmpdir, "imm_rates_orig.png"))
+    parameter_plots.plot_imm_rates(base_params.imm_rates, base_params.start_year, [base_params.start_year], path=tmpdir)
+    img = mpimg.imread(os.path.join(tmpdir, "imm_rates.png"))
 
     assert isinstance(img, np.ndarray)
 
@@ -173,9 +173,9 @@ def test_plot_fert_rates():
     )
     age_midp = np.array([9, 10, 12, 16, 18.5, 22, 27, 32, 37, 42, 47, 55, 56])
     fert_func = si.interp1d(age_midp, fert_data, kind="cubic")
-    fert_rates = np.random.uniform(size=totpers)
+    fert_rates = np.random.uniform(size=totpers).reshape((1, totpers))
     fig = parameter_plots.plot_fert_rates(
-        fert_func, age_midp, totpers, min_yr, max_yr, fert_data, fert_rates
+        fert_rates
     )
     assert fig
 
@@ -206,16 +206,10 @@ def test_plot_fert_rates_save_fig(tmpdir):
     )
     age_midp = np.array([9, 10, 12, 16, 18.5, 22, 27, 32, 37, 42, 47, 55, 56])
     fert_func = si.interp1d(age_midp, fert_data, kind="cubic")
-    fert_rates = np.random.uniform(size=totpers)
+    fert_rates = np.random.uniform(size=totpers).reshape((1, totpers))
     parameter_plots.plot_fert_rates(
-        fert_func,
-        age_midp,
-        totpers,
-        min_yr,
-        max_yr,
-        fert_data,
         fert_rates,
-        output_dir=tmpdir,
+        path=tmpdir,
     )
     img = mpimg.imread(os.path.join(tmpdir, "fert_rates.png"))
 
@@ -224,42 +218,20 @@ def test_plot_fert_rates_save_fig(tmpdir):
 
 def test_plot_mort_rates_data():
     totpers = base_params.S - 1
-    min_yr = 21
-    max_yr = 100
-    age_year_all = np.arange(min_yr, max_yr)
-    mort_rates = base_params.rho[-1, 1:].squeeze()
-    mort_rates_all = base_params.rho[-1, 1:].squeeze()
-    infmort_rate = base_params.rho[0, 0]
+    mort_rates = base_params.rho[-1, 1:].reshape((1, totpers))
     fig = parameter_plots.plot_mort_rates_data(
-        totpers,
-        min_yr,
-        max_yr,
-        age_year_all,
-        mort_rates_all,
-        infmort_rate,
         mort_rates,
-        output_dir=None,
+        path=None,
     )
     assert fig
 
 
 def test_plot_mort_rates_data_save_fig(tmpdir):
     totpers = base_params.S - 1
-    min_yr = 21
-    max_yr = 100
-    age_year_all = np.arange(min_yr, max_yr)
-    mort_rates = base_params.rho[-1, 1:].squeeze()
-    mort_rates_all = base_params.rho[-1, 1:].squeeze()
-    infmort_rate = base_params.rho[0, 0]
+    mort_rates = base_params.rho[-1, 1:].reshape((1, totpers))
     parameter_plots.plot_mort_rates_data(
-        totpers,
-        min_yr,
-        max_yr,
-        age_year_all,
-        mort_rates_all,
-        infmort_rate,
         mort_rates,
-        output_dir=tmpdir,
+        path=tmpdir,
     )
     img = mpimg.imread(os.path.join(tmpdir, "mort_rates.png"))
 
@@ -285,7 +257,7 @@ def test_plot_omega_fixed_save_fig(tmpdir):
     omega_SS_orig = base_params.omega_SS
     omega_SSfx = base_params.omega_SS
     parameter_plots.plot_omega_fixed(
-        age_per_EpS, omega_SS_orig, omega_SSfx, E, S, output_dir=tmpdir
+        age_per_EpS, omega_SS_orig, omega_SSfx, E, S, path=tmpdir
     )
     img = mpimg.imread(os.path.join(tmpdir, "OrigVsFixSSpop.png"))
 
@@ -311,7 +283,7 @@ def test_plot_imm_fixed_save_fig(tmpdir):
     imm_rates_orig = base_params.imm_rates[0, :]
     imm_rates_adj = base_params.imm_rates[-1, :]
     parameter_plots.plot_imm_fixed(
-        age_per_EpS, imm_rates_orig, imm_rates_adj, E, S, output_dir=tmpdir
+        age_per_EpS, imm_rates_orig, imm_rates_adj, E, S, path=tmpdir
     )
     img = mpimg.imread(os.path.join(tmpdir, "OrigVsAdjImm.png"))
 
@@ -322,7 +294,7 @@ def test_plot_population_path():
     S = base_params.S
     age_per_EpS = np.arange(21, S + 21)
     initial_pop_pct = base_params.omega[0, :]
-    omega_path_lev = base_params.omega.T
+    omega_path_lev = base_params.omega
     omega_SSfx = base_params.omega_SS
     data_year = base_params.start_year
     curr_year = base_params.start_year
@@ -343,7 +315,7 @@ def test_plot_population_path_save_fig(tmpdir):
     S = base_params.S
     age_per_EpS = np.arange(21, S + 21)
     pop_2013_pct = base_params.omega[0, :]
-    omega_path_lev = base_params.omega.T
+    omega_path_lev = base_params.omega
     omega_SSfx = base_params.omega_SS
     curr_year = base_params.start_year
     parameter_plots.plot_population_path(
@@ -354,7 +326,7 @@ def test_plot_population_path_save_fig(tmpdir):
         curr_year,
         E,
         S,
-        output_dir=tmpdir,
+        path=tmpdir,
     )
     img = mpimg.imread(os.path.join(tmpdir, "PopDistPath.png"))
 
@@ -385,7 +357,7 @@ def test_plot_income_data_save_fig(tmpdir):
     abil_pcts = np.array([0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01])
     emat = p.e
     parameter_plots.plot_income_data(
-        ages, abil_midp, abil_pcts, emat, output_dir=tmpdir
+        ages, abil_midp, abil_pcts, emat, path=tmpdir
     )
     img1 = mpimg.imread(os.path.join(tmpdir, "ability_3D_lev.png"))
     img2 = mpimg.imread(os.path.join(tmpdir, "ability_3D_log.png"))

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -44,12 +44,22 @@ base_params.rho = np.tile(
 
 
 def test_plot_imm_rates():
-    fig = parameter_plots.plot_imm_rates(base_params.imm_rates, base_params.start_year, [base_params.start_year], include_title=True)
+    fig = parameter_plots.plot_imm_rates(
+        base_params.imm_rates,
+        base_params.start_year,
+        [base_params.start_year],
+        include_title=True,
+    )
     assert fig
 
 
 def test_plot_imm_rates_save_fig(tmpdir):
-    parameter_plots.plot_imm_rates(base_params.imm_rates, base_params.start_year, [base_params.start_year], path=tmpdir)
+    parameter_plots.plot_imm_rates(
+        base_params.imm_rates,
+        base_params.start_year,
+        [base_params.start_year],
+        path=tmpdir,
+    )
     img = mpimg.imread(os.path.join(tmpdir, "imm_rates.png"))
 
     assert isinstance(img, np.ndarray)
@@ -174,9 +184,7 @@ def test_plot_fert_rates():
     age_midp = np.array([9, 10, 12, 16, 18.5, 22, 27, 32, 37, 42, 47, 55, 56])
     fert_func = si.interp1d(age_midp, fert_data, kind="cubic")
     fert_rates = np.random.uniform(size=totpers).reshape((1, totpers))
-    fig = parameter_plots.plot_fert_rates(
-        fert_rates
-    )
+    fig = parameter_plots.plot_fert_rates(fert_rates)
     assert fig
 
 

--- a/tests/test_run_example.py
+++ b/tests/test_run_example.py
@@ -2,6 +2,7 @@
 This test tests whether starting a `run_ogcore_example.py` run of the model does
 not break down (is still running) after 5 minutes or 300 seconds.
 """
+
 import multiprocessing
 import time
 import os


### PR DESCRIPTION
This PR creates a demographic module in OG-Core.  Such a module exists in the various country calibration repositories, but since all of those now use the UN population data, much of the code is repeated.  Thus, moving the module here will remove redundant code across these country-specific repos.

In addition to this, the PR will add the following functionality:
1. The ability for users to use the time-varying forecasts from the UN WPP, up to a user-specified end date (or the maximum date available from the UN).
2. Users can enter their own custom forecasts of fertility, mortality, and immigration rates.
3. Users can enter their own estimate of the initial population distribution (Note that doing 2 and 3 together will bypass the use of UN data and use `demographics.py` purely for filling out demographic variables over the transition path and in the SS).
4. A country code parameter to specify which country's forecast to pull from the UN data.
5. Streamlines the plotting utilities and allows users to return a Matplotlib figure object (not just save a plot image file to disk).