### PR TITLE
Update Python version to be <3.12 in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2024-02-12 15:00:00
+
+### Added
+
+- Updated `setup.py` Python version requirement to be `python_requires=">=3.7.7, <3.12"`
+
 ## [0.11.0] - 2024-02-06 15:00:00
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[0.11.1]: https://github.com/PSLmodels/OG-Core/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/PSLmodels/OG-Core/compare/v0.10.10...v0.11.0
 [0.10.10]: https://github.com/PSLmodels/OG-Core/compare/v0.10.9...v0.10.10
 [0.10.9]: https://github.com/PSLmodels/OG-Core/compare/v0.10.8...v0.10.9

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.11.0",
+    version="0.11.1",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",
@@ -23,7 +23,7 @@ setuptools.setup(
         ]
     },
     include_packages=True,
-    python_requires=">=3.7.7",
+    python_requires=">=3.7.7, <3.12",
     install_requires=[
         "scipy>=1.7.1",
         "pandas>=1.2.5",


### PR DESCRIPTION
This PR updates the Python version requirements in `setup.py` to be `python_requires=">=3.7.7, <3.12"`. The new addition is the `<3.12` piece. This requirement is in `environment.yml`. However, when OG-Core is pip installed, it uses `setup.py` and will sometimes install Python 3.12. The PR makes the Python version always be < 3.12.

cc: @jdebacker 