### PR TITLE
Added entries at end of CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [0.11.4] - 2024-04-03 22:00:00
 
 ### Added
@@ -13,12 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a function to `utils.py` to compute percentage changes in non-stationary variables
 - Add more functionality to `parameters_plots.py`, allowing the user to plot parameters from multiple parameters objects together
 
+
 ## [0.11.3] - 2024-03-08 12:00:00
 
 ### Added
 
 - Allow for `demographics.py` to save downloaded data directly.
 - Retrieve population data from the UN World Population Prospects database through CSV rather than JSON to avoid rate limit errors.
+
 
 ## [0.11.2] - 2024-02-17 12:00:00
 
@@ -29,11 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extends all series returned from the get_pop_objs() function over the full transition path of T+S periods (except those that apply only to a single period).
 - Addresses Issues #900 and #899
 
+
 ## [0.11.1] - 2024-02-12 15:00:00
 
 ### Added
 
 - Updated `setup.py` Python version requirement to be `python_requires=">=3.7.7, <3.12"`
+
 
 ## [0.11.0] - 2024-02-06 15:00:00
 
@@ -205,7 +210,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
-
+[0.11.4]: https://github.com/PSLmodels/OG-Core/compare/v0.11.3...v0.11.4
+[0.11.3]: https://github.com/PSLmodels/OG-Core/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/PSLmodels/OG-Core/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/PSLmodels/OG-Core/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/PSLmodels/OG-Core/compare/v0.10.10...v0.11.0


### PR DESCRIPTION
This PR adds two entries to the end of `CHANGELOG.md` that create hyperlinks to version 0.11.3 and 0.11.4 that compare those versions to the previous versions. I don't think the link to version 0.11.3 will work because we never tagged that update.