### PR TITLE
Generalizations in `output_plots.py`

### DIFF
--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -66,6 +66,7 @@ def plot_aggregates(
     """
     assert isinstance(start_year, (int, np.integer))
     assert isinstance(num_years_to_plot, int)
+    assert num_years_to_plot <= base_params.T
     # Make sure both runs cover same time period
     if reform_tpi:
         assert base_params.start_year == reform_params.start_year
@@ -221,6 +222,7 @@ def plot_industry_aggregates(
     """
     assert isinstance(start_year, (int, np.integer))
     assert isinstance(num_years_to_plot, int)
+    assert num_years_to_plot <= base_params.T
     dims = base_tpi[var_list[0]].shape[1]
     if ind_names_list:
         assert len(ind_names_list) == dims
@@ -438,6 +440,7 @@ def plot_gdp_ratio(
     """
     assert isinstance(start_year, (int, np.integer))
     assert isinstance(num_years_to_plot, int)
+    assert num_years_to_plot <= base_params.T
     if plot_type == "diff":
         assert reform_tpi is not None
     # Make sure both runs cover same time period
@@ -865,7 +868,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_params=reform_params,
         var_list=["Y", "K", "L", "C"],
         plot_type="pct_diff",
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -883,7 +886,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_params=reform_params,
         var_list=["D", "G", "TR", "total_tax_revenue"],
         plot_type="pct_diff",
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -901,7 +904,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_params=reform_params,
         var_list=["r"],
         plot_type="levels",
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -918,7 +921,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_params=reform_params,
         var_list=["w"],
         plot_type="levels",
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -935,7 +938,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_tpi,
         reform_params,
         var_list=["D"],
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -952,7 +955,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         reform_tpi,
         reform_params,
         var_list=["total_tax_revenue"],
-        num_years_to_plot=150,
+        num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
         vertical_line_years=[
             base_params.start_year + base_params.tG1,
@@ -1096,6 +1099,7 @@ def inequality_plot(
     """
     assert isinstance(start_year, (int, np.integer))
     assert isinstance(num_years_to_plot, int)
+    assert num_years_to_plot <= base_params.T
     # Make sure both runs cover same time period
     if reform_tpi:
         assert base_params.start_year == reform_params.start_year

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -1188,3 +1188,27 @@ def inequality_plot(
     else:
         return fig1
     plt.close()
+
+
+def lambda_labels(lambdas):
+    """
+    Creates string labels of percentage groups for ability types given
+    any number of ability types.
+
+    Args:
+        lambdas (np.array): array of lambdas for each ability type
+
+    Returns:
+        labels (list): list of string labels for ability types
+    """
+    lambdas_100 = lambdas #[round(x, 1) for x in lambdas]
+    lambdas_cumsum = list(np.cumsum(lambdas_100))
+    lambdas_cumsum = [round(x*100, 2) for x in lambdas_cumsum]
+    lambdas_cumsum = [0.00] + lambdas_cumsum
+    lambda_dict = {}
+    for i in range(1, len(lambdas_cumsum)):
+        lambda_dict[i-1] = (str(lambdas_cumsum[i-1]) + "-" + str(lambdas_cumsum[i]) + "%")
+    if lambdas_100[-1] < 100:
+        lambda_dict[i] = "Top " + str(100 - lambdas_cumsum[-1]) + "%"
+
+    return lambda_dict

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -1204,9 +1204,26 @@ def lambda_labels(lambdas):
     lambdas_cumsum = list(np.cumsum(lambdas_100))
     lambdas_cumsum = [0.00] + lambdas_cumsum
     lambda_dict = {}
-    for i in range(1, len(lambdas_cumsum) - 1):
+    rounded = []  # list of rounded values, strings
+    for i in range(len(lambdas_cumsum)):
         # condition formatting to number of digits need, but not more than 2
-        lambda_dict[i-1] = (f'{lambdas_cumsum[i-1]:.2f}' + "-" + f'{lambdas_cumsum[i]:.2f}' + "%")
-    lambda_dict[i] = "Top " + f'{(100 - lambdas_cumsum[-2]):.2f}' + "%"
+        if lambdas_cumsum[i] % 1 == 0:
+            round_i = f"{lambdas_cumsum[i]:.0f}"
+        elif lambdas_cumsum[i] % 0.1 == 0:
+            round_i = f"{lambdas_cumsum[i]:.1f}"
+        else:
+            round_i = f"{lambdas_cumsum[i]:.2f}"
+        rounded.append(round_i)
+    for i in range(1, len(lambdas_cumsum) - 1):
+        lambda_dict[i - 1] = rounded[i - 1] + "-" + rounded[i] + "%"
+        # and do rounding for the top
+        top_number = 100 - lambdas_cumsum[-2]
+        if top_number % 1 == 0:
+            top_number_str = f"{top_number:.0f}"
+        elif top_number % 0.1 == 0:
+            top_number_str = f"{top_number:.1f}"
+        else:
+            top_number_str = f"{top_number:.2f}"
+    lambda_dict[i] = "Top " + top_number_str + "%"
 
     return lambda_dict

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib
 from ogcore.constants import (
-    GROUP_LABELS,
     VAR_LABELS,
     ToGDP_LABELS,
     DEFAULT_START_YEAR,
@@ -586,7 +585,7 @@ def ability_bar(
     var_to_plot = (reform_val - base_val) / base_val
     ax.bar(ind, var_to_plot * 100, width, bottom=0)
     ax.set_xticks(ind + width / 4)
-    ax.set_xticklabels(list(GROUP_LABELS[base_params.J].values()))
+    ax.set_xticklabels(list(lambda_labels(base_params.lambdas).values()))
     plt.xticks(rotation=45)
     plt.ylabel(r"Percentage Change in " + VAR_LABELS[var])
     if plot_title:
@@ -639,7 +638,7 @@ def ability_bar_ss(
     var_to_plot = (reform_val - base_val) / base_val
     ax.bar(ind, var_to_plot * 100, width, bottom=0)
     ax.set_xticks(ind + width / 4)
-    ax.set_xticklabels(list(GROUP_LABELS[base_params.J].values()))
+    ax.set_xticklabels(list(lambda_labels(base_params.lambdas).values()))
     plt.xticks(rotation=45)
     plt.ylabel(r"Percentage Change in " + VAR_LABELS[var])
     if plot_title:
@@ -1199,16 +1198,15 @@ def lambda_labels(lambdas):
         lambdas (np.array): array of lambdas for each ability type
 
     Returns:
-        labels (list): list of string labels for ability types
+        labels (dict): dict of string labels for ability types
     """
-    lambdas_100 = lambdas #[round(x, 1) for x in lambdas]
+    lambdas_100 = [x * 100 for x in lambdas]
     lambdas_cumsum = list(np.cumsum(lambdas_100))
-    lambdas_cumsum = [round(x*100, 2) for x in lambdas_cumsum]
     lambdas_cumsum = [0.00] + lambdas_cumsum
     lambda_dict = {}
-    for i in range(1, len(lambdas_cumsum)):
-        lambda_dict[i-1] = (str(lambdas_cumsum[i-1]) + "-" + str(lambdas_cumsum[i]) + "%")
-    if lambdas_100[-1] < 100:
-        lambda_dict[i] = "Top " + str(100 - lambdas_cumsum[-1]) + "%"
+    for i in range(1, len(lambdas_cumsum) - 1):
+        # condition formatting to number of digits need, but not more than 2
+        lambda_dict[i-1] = (f'{lambdas_cumsum[i-1]:.2f}' + "-" + f'{lambdas_cumsum[i]:.2f}' + "%")
+    lambda_dict[i] = "Top " + f'{(100 - lambdas_cumsum[-2]):.2f}' + "%"
 
     return lambda_dict

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -562,15 +562,9 @@ def test_lambda_labels():
     """
     Test of the lambda_labels function in output_plots.py
     """
-    labels = output_plots.lambda_labels([
-                    0.25,
-                    0.25,
-                    0.2,
-                    0.1,
-                    0.1,
-                    0.09,
-                    0.01
-                ])
+    labels = output_plots.lambda_labels(
+        [0.25, 0.25, 0.2, 0.1, 0.1, 0.09, 0.01]
+    )
     print(labels)
     for k, v in labels.items():
         print(k, v)

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -7,7 +7,7 @@ import os
 import sys
 import numpy as np
 import matplotlib.image as mpimg
-from ogcore import utils, output_plots
+from ogcore import utils, output_plots, constants
 
 
 # Load in test results and parameters
@@ -556,3 +556,22 @@ def test_plot_all(tmpdir):
         assert isinstance(img3, np.ndarray)
     else:
         assert True
+
+
+def test_lambda_labels():
+    """
+    Test of the lambda_labels function in output_plots.py
+    """
+    labels = output_plots.lambda_labels([
+                    0.25,
+                    0.25,
+                    0.2,
+                    0.1,
+                    0.1,
+                    0.09,
+                    0.01
+                ])
+    print(labels)
+    for k, v in labels.items():
+        print(k, v)
+        assert v == constants.GROUP_LABELS[7][k]


### PR DESCRIPTION
This PR does to things to make `output_plots.py` work better with different parameterizations:

1. It ensures that the `num_years_to_plot` is less than `T` (or raises an assertion if not).
2. Labels for ability types are generalized to work with any `lambdas` values.

Addresses Issue #757 