### PR TITLE
Set threads per worker to 1

### DIFF
--- a/run_examples/run_ogcore_example.py
+++ b/run_examples/run_ogcore_example.py
@@ -27,7 +27,7 @@ def main():
     # Define parameters to use for multiprocessing
     num_workers = min(multiprocessing.cpu_count(), 7)
     print("Number of workers = ", num_workers)
-    client = Client(n_workers=num_workers)
+    client = Client(n_workers=num_workers, threads_per_worker=1)
     run_start_time = time.time()
 
     # Directories to save data


### PR DESCRIPTION
This PR updates the `run_ogcore_example.py` script to use just one thread per worker in the dask client. This was pointed out by @talumbau in OG-USA [PR #102](https://github.com/PSLmodels/OG-USA/pull/102) to reduce run times and excessive memory usage.