### PR TITLE
Fix error converting to pct diffs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pytest -m "not local" --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/OG-Core')
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -95,7 +95,7 @@ def plot_aggregates(
             ylabel = r"Pct. change"
             plt.plot(
                 year_vec,
-                plot_var[start_index : start_index + num_years_to_plot] * 100,
+                plot_var[start_index : start_index + num_years_to_plot],
                 label=VAR_LABELS[v],
             )
         elif plot_type == "diff":

--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -883,7 +883,7 @@ def plot_all(base_output_path, reform_output_path, save_path):
         base_params,
         reform_tpi=reform_tpi,
         reform_params=reform_params,
-        var_list=["D", "G", "TR", "total_tax_revenue"],
+        var_list=["D", "TR", "total_tax_revenue"],
         plot_type="pct_diff",
         num_years_to_plot=min(base_params.T, 150),
         start_year=base_params.start_year,
@@ -928,6 +928,23 @@ def plot_all(base_output_path, reform_output_path, save_path):
         ],
         plot_title="Wage Rates Under Baseline and Reform",
         path=os.path.join(save_path, "WageRates.png"),
+    )
+
+    # Gov't spending toGDP in base and reform-- vertical lines at tG1, tG2
+    plot_gdp_ratio(
+        base_tpi,
+        base_params,
+        reform_tpi,
+        reform_params,
+        var_list=["G"],
+        num_years_to_plot=min(base_params.T, 150),
+        start_year=base_params.start_year,
+        vertical_line_years=[
+            base_params.start_year + base_params.tG1,
+            base_params.start_year + base_params.tG2,
+        ],
+        plot_title="Gov't Spending-to-GDP",
+        path=os.path.join(save_path, "SpendGDPratio.png"),
     )
 
     # Debt-GDP in base and reform-- vertical lines at tG1, tG2


### PR DESCRIPTION
In PR #914, I introduced an error into the `output_plots.plot_aggregates` function.  In this case, I multiplied the pct diffs by 100 to get them in percentage points, forgetting that the plot formatting options used:

```python
if plot_type == "pct_diff":
        ax1.set_yticklabels(["{:,.2%}".format(x) for x in vals])
```

already take care of this.  Thus, the effect of my change was to make the pct diffs look 100 times as large.

This PR fixes that error.