### PR TITLE
Update demographics.py to use new UN API format and token

### DIFF
--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -45,6 +45,8 @@ def get_un_data(
     for UN population data (see
     https://population.un.org/dataportal/about/dataapi)
 
+    Requires a API token in file "un_api_token.txt"
+
     Args:
         variable_code (str): variable code for UN data
         country_id (str): country id for UN data
@@ -54,6 +56,11 @@ def get_un_data(
     Returns:
         df (Pandas DataFrame): DataFrame of UN data
     """
+
+    # Load the token from a local file
+    with open("un_api_token.txt", "r") as file:
+        un_token = file.read().strip()
+
     target = (
         "https://population.un.org/dataportalapi/api/v1/data/indicators/"
         + variable_code
@@ -66,8 +73,11 @@ def get_un_data(
         + "?format=csv"
     )
 
+    payload = {}
+    headers = {"Authorization": un_token}
+
     # get data from url
-    response = get_legacy_session().get(target)
+    response = get_legacy_session().get(target, headers=headers, data=payload)
     # Check if the request was successful before processing
     if response.status_code == 200:
 
@@ -374,7 +384,7 @@ def get_pop(
             )
     else:
         # Read UN data
-        for y in range(start_year, end_year + 2):
+        for y in range(start_year, end_year):
             pop_data = get_un_data(
                 "47",
                 country_id=country_id,


### PR DESCRIPTION
Making it compatible with un API token use. Also to fix an error when downloading the full dataset (end year = 2100) in line 377 `demographics.py`. This will likely create other problems, so it needs to be evaluated. Still running into an assertion error:

```
Demographics data: Initial Data year =  2020 , Final Data year =  2100
Traceback (most recent call last):
  File "/Users/mlafleur/Projects/OG-ZAF/tests/test_demog_jdebacker.py", line 5, in <module>
    c = Calibration(p, estimate_pop=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mlafleur/Projects/OG-ZAF/ogzaf/calibrate.py", line 98, in __init__
    self.demographic_params = demographics.get_pop_objs(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mlafleur/opt/anaconda3/envs/ogzaf-dev/lib/python3.11/site-packages/ogcore/demographics.py", line 909, in get_pop_objs
    assert np.allclose(pop_counter_2D, pop_2D)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```