### PR TITLE
Updates to `demographics.py` for changes in UN API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ regression/OUTPUT_BASELINE/*
 regression/OUTPUT_REFORM*
 .vscode/
 *default.profraw
+*un_api_token.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.8] - 2024-06-09 01:00:00
+
+### Added
+
+- Updates to `demographics.py` module to accept token for UN World Population Prospects database access or to download data from the [Population-Data](https://github.com/EAPD-DRB/Population-Data) repository.
 
 ## [0.11.7] - 2024-06-07 01:00:00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.11.8]: https://github.com/PSLmodels/OG-Core/compare/v0.11.7...v0.11.8
 [0.11.7]: https://github.com/PSLmodels/OG-Core/compare/v0.11.6...v0.11.7
 [0.11.6]: https://github.com/PSLmodels/OG-Core/compare/v0.11.5...v0.11.6
 [0.11.5]: https://github.com/PSLmodels/OG-Core/compare/v0.11.4...v0.11.5

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -80,7 +80,6 @@ def get_un_data(
     # get data from url
     payload = {}
     headers = {"Authorization": UN_TOKEN}
-    print("UN Token  = ", UN_TOKEN)
     response = get_legacy_session().get(target, headers=headers, data=payload)
     # Check if the request was successful before processing
     if response.status_code == 200:
@@ -150,13 +149,8 @@ def get_fert(
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
-        fert_rates = df_y.value.values
-        # fill in with zeros for ages  < 15 and > 49
-        # NOTE: this assumes min_year < 15 and max_age > 49
-        fert_rates = np.append(fert_rates, np.zeros(max_age - 49))
-        fert_rates = np.append(np.zeros(15 - min_age), fert_rates)
         # put in vector
-        fert_rates = df.value.values
+        fert_rates = df_y.value.values
         # fill in with zeros for ages  < 15 and > 49
         # NOTE: this assumes min_year < 15 and max_age > 49
         fert_rates = np.append(fert_rates, np.zeros(max_age - 49))
@@ -179,7 +173,7 @@ def get_fert(
 
     # Create plots if needed
     if graph:
-        if plot_path:
+        if plot_path is not None:
             pp.plot_fert_rates(
                 [fert_rates_2D],
                 start_year=start_year,
@@ -269,7 +263,7 @@ def get_mort(
 
     # Create plots if needed
     if graph:
-        if plot_path:
+        if plot_path is not None:
             pp.plot_mort_rates_data(
                 mort_rates_2D,
                 start_year,
@@ -570,13 +564,11 @@ def get_imm_rates(
             pop_t = pop_rebin(pop_t, totpers)
             pop_dist[y - start_year, :] = pop_t
     # Make sure shape conforms
-    print("pop_dist shape = ", pop_dist.shape)
-    print("mort_rates shape = ", mort_rates.shape)
     assert pop_dist.shape[1] == mort_rates.shape[1]
     assert pop_dist.shape[0] == end_year - start_year + 2
     for y in range(start_year, end_year + 1):
         pop_t = pop_dist[y - start_year, :]
-        pop_tp1 = pop_dist[y - start_year + 1, :]
+        pop_tp1 = pop_dist[y + 1 - start_year, :]
         # initialize imm_rate vector
         imm_rates = np.zeros(totpers)
         # back out imm rates by age for each year
@@ -601,7 +593,7 @@ def get_imm_rates(
 
     # Create plots if needed
     if graph:
-        if plot_path:
+        if plot_path is not None:
             pp.plot_imm_rates(
                 imm_rates_2D,
                 start_year,
@@ -767,8 +759,8 @@ def get_pop_objs(
     ):
         global UN_TOKEN
         # Check for a file named "un_api_token.txt" in the current directory
-        if os.path.exists("./ogcore/un_api_token.txt"):
-            with open("./ogcore/un_api_token.txt", "r") as file:
+        if os.path.exists(os.path.join("un_api_token.txt")):
+            with open(os.path.join("un_api_token.txt"), "r") as file:
                 UN_TOKEN = file.read().strip()
         else:  # if file not exist, prompt user for token
             UN_TOKEN = input("Please enter your UN API token: ")

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -27,6 +27,17 @@ if os.access(OUTPUT_DIR, os.F_OK) is False:
     os.makedirs(OUTPUT_DIR)
 
 
+# UN data API token
+# global UN_TOKEN
+# # UN_TOKEN = None
+# global UN_TOKEN
+# Check for a file named "un_api_token.txt" in the current directory
+# if os.path.exists("./ogusa/un_api_token.txt"):
+#     with open("un_api_token.txt", "r") as file:
+#         UN_TOKEN = file.read().strip()
+# else:  # if file not exist, prompt user for token
+#     UN_TOKEN = input("Please enter your UN API token: ")
+
 """
 ------------------------------------------------------------------------
 Define functions
@@ -67,7 +78,10 @@ def get_un_data(
     )
 
     # get data from url
-    response = get_legacy_session().get(target)
+    payload = {}
+    headers = {"Authorization": UN_TOKEN}
+    print("UN Token  = ", UN_TOKEN)
+    response = get_legacy_session().get(target, headers=headers, data=payload)
     # Check if the request was successful before processing
     if response.status_code == 200:
 
@@ -723,6 +737,19 @@ def get_pop_objs(
         assert (
             infer_pop is True
         )  # if pass immigration rates, need to infer population
+
+    # Check that user is going to need access to demographic data from
+    # the UN. If so, prompt them for their API token.
+    # Prompt the user to enter their name
+    if (fert_rates is None or mort_rates is None or infmort_rates is None
+        or imm_rates is None or pop_dist is None):
+        global UN_TOKEN
+        # Check for a file named "un_api_token.txt" in the current directory
+        if os.path.exists("./ogcore/un_api_token.txt"):
+            with open("./ogcore/un_api_token.txt", "r") as file:
+                UN_TOKEN = file.read().strip()
+        else:  # if file not exist, prompt user for token
+            UN_TOKEN = input("Please enter your UN API token: ")
 
     # Get fertility rates if not provided
     if fert_rates is None:

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -146,6 +146,8 @@ def get_fert(
     df = get_un_data(
         "68", country_id=country_id, start_year=start_year, end_year=end_year
     )
+    if download_path:
+        df.to_csv(os.path.join(download_path, "raw_fert_data_UN.csv"), index=False)
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -232,6 +234,8 @@ def get_mort(
     df = get_un_data(
         "80", country_id=country_id, start_year=start_year, end_year=end_year
     )
+    if download_path:
+        df.to_csv(os.path.join(download_path, "raw_mort_data_UN.csv"), index=False)
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -345,6 +349,8 @@ def get_pop(
                 start_year=start_year - 1,
                 end_year=start_year - 1,
             )
+            if download_path:
+                pre_pop_data.to_csv(os.path.join(download_path, "raw_pre_pop_data_UN.csv"), index=False)
             pre_pop_sample = pre_pop_data[
                 (pre_pop_data["age"] >= min_age)
                 & (pre_pop_data["age"] <= max_age)
@@ -397,6 +403,8 @@ def get_pop(
             end_year=end_year
             + 2,  # note go to + 2 because needed to infer immigration for end_year
         )
+        if download_path:
+            pop_data.to_csv(os.path.join(download_path, "raw_pop_data_UN.csv"), index=False)
         # CLean and rebin data
         for y in range(start_year, end_year + 2):
             pop_data_sample = pop_data[
@@ -663,7 +671,7 @@ def get_pop_objs(
     pre_pop_dist=None,
     country_id=UN_COUNTRY_CODE,
     initial_data_year=START_YEAR - 1,
-    final_data_year=START_YEAR + 2,  # as default data year goes until T1
+    final_data_year=START_YEAR + 2,
     GraphDiag=True,
     download_path=None,
 ):
@@ -733,8 +741,8 @@ def get_pop_objs(
         final_data_year,
     )
     assert E + S <= max_age - min_age + 1
-    assert initial_data_year >= 2011 and initial_data_year <= 2100
-    assert final_data_year >= 2011 and final_data_year <= 2100
+    assert initial_data_year >= 2011 and initial_data_year <= 2100 - 1
+    assert final_data_year >= 2011 and final_data_year <= 2100 - 1
     # Ensure that the last year of data used is before SS transition assumed
     # Really, it will need to be well before this
     assert final_data_year > initial_data_year

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -147,7 +147,9 @@ def get_fert(
         "68", country_id=country_id, start_year=start_year, end_year=end_year
     )
     if download_path:
-        df.to_csv(os.path.join(download_path, "raw_fert_data_UN.csv"), index=False)
+        df.to_csv(
+            os.path.join(download_path, "raw_fert_data_UN.csv"), index=False
+        )
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -235,7 +237,9 @@ def get_mort(
         "80", country_id=country_id, start_year=start_year, end_year=end_year
     )
     if download_path:
-        df.to_csv(os.path.join(download_path, "raw_mort_data_UN.csv"), index=False)
+        df.to_csv(
+            os.path.join(download_path, "raw_mort_data_UN.csv"), index=False
+        )
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -350,7 +354,10 @@ def get_pop(
                 end_year=start_year - 1,
             )
             if download_path:
-                pre_pop_data.to_csv(os.path.join(download_path, "raw_pre_pop_data_UN.csv"), index=False)
+                pre_pop_data.to_csv(
+                    os.path.join(download_path, "raw_pre_pop_data_UN.csv"),
+                    index=False,
+                )
             pre_pop_sample = pre_pop_data[
                 (pre_pop_data["age"] >= min_age)
                 & (pre_pop_data["age"] <= max_age)
@@ -404,7 +411,9 @@ def get_pop(
             + 2,  # note go to + 2 because needed to infer immigration for end_year
         )
         if download_path:
-            pop_data.to_csv(os.path.join(download_path, "raw_pop_data_UN.csv"), index=False)
+            pop_data.to_csv(
+                os.path.join(download_path, "raw_pop_data_UN.csv"), index=False
+            )
         # CLean and rebin data
         for y in range(start_year, end_year + 2):
             pop_data_sample = pop_data[

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -77,13 +77,14 @@ def get_un_data(
         + "?format=csv"
     )
 
-
     # Check for a file named "un_api_token.txt" in the current directory
     if os.path.exists(os.path.join("un_api_token.txt")):
         with open(os.path.join("un_api_token.txt"), "r") as file:
             UN_TOKEN = file.read().strip()
     else:  # if file not exist, prompt user for token
-        UN_TOKEN = input("Please enter your UN API token (press return if you do not have one): ")
+        UN_TOKEN = input(
+            "Please enter your UN API token (press return if you do not have one): "
+        )
         # write the UN_TOKEN to a file to find in the future
         with open(os.path.join("un_api_token.txt"), "w") as file:
             file.write(UN_TOKEN)
@@ -112,25 +113,29 @@ def get_un_data(
     else:
         # Read from UN GH Repo:
         print(
-            f"Failed to retrieve population data from UN. Reading " +
-            " from https://github.com/EAPD-DRB/Population-Data " +
-            "instead of UN WPP API"
+            f"Failed to retrieve population data from UN. Reading "
+            + " from https://github.com/EAPD-DRB/Population-Data "
+            + "instead of UN WPP API"
         )
         country_dict = {
             "840": "USA",
             "710": "ZAF",
             "458": "MYS",
             "356": "IND",
-            "826": "UK"
+            "826": "UK",
         }
         un_variable_dict = {
             "68": "fertility_rates",
             "80": "mortality_rates",
-            "47": "population"
+            "47": "population",
         }
         country = country_dict[country_id]
         variable = un_variable_dict[variable_code]
-        url = "https://raw.githubusercontent.com/EAPD-DRB/Population-Data/main/Data/{c}/UN_{v}_data.csv".format(c=country, v=variable)
+        url = (
+            "https://raw.githubusercontent.com/EAPD-DRB/"
+            + "Population-Data/main/"
+            + "Data/{c}/UN_{v}_data.csv".format(c=country, v=variable)
+        )
         df = pd.read_csv(url)
         # keep just the years requested
         df = df[(df.year >= start_year) & (df.year <= end_year)]

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -77,6 +77,17 @@ def get_un_data(
         + "?format=csv"
     )
 
+
+    # Check for a file named "un_api_token.txt" in the current directory
+    if os.path.exists(os.path.join("un_api_token.txt")):
+        with open(os.path.join("un_api_token.txt"), "r") as file:
+            UN_TOKEN = file.read().strip()
+    else:  # if file not exist, prompt user for token
+        UN_TOKEN = input("Please enter your UN API token (press return if you do not have one): ")
+        # write the UN_TOKEN to a file to find in the future
+        with open(os.path.join("un_api_token.txt"), "w") as file:
+            file.write(UN_TOKEN)
+
     # get data from url
     payload = {}
     headers = {"Authorization": UN_TOKEN}
@@ -99,9 +110,13 @@ def get_un_data(
         df.year = df.year.astype(int)
         df = df[df.age < 100]  # need to drop 100+ age category
     else:
-        print(
-            f"Failed to retrieve population data. HTTP status code: {response.status_code}"
-        )
+        # Read from UN GH Repo:
+        # TODO: put code to do this here...
+
+        # Do we still want to keep the status code for failures?
+        # print(
+        #     f"Failed to retrieve population data. HTTP status code: {response.status_code}"
+        # )
         assert False
 
     return df
@@ -763,24 +778,6 @@ def get_pop_objs(
         assert (
             infer_pop is True
         )  # if pass immigration rates, need to infer population
-
-    # Check that user is going to need access to demographic data from
-    # the UN. If so, prompt them for their API token.
-    # Prompt the user to enter their name
-    if (
-        fert_rates is None
-        or mort_rates is None
-        or infmort_rates is None
-        or imm_rates is None
-        or pop_dist is None
-    ):
-        global UN_TOKEN
-        # Check for a file named "un_api_token.txt" in the current directory
-        if os.path.exists(os.path.join("un_api_token.txt")):
-            with open(os.path.join("un_api_token.txt"), "r") as file:
-                UN_TOKEN = file.read().strip()
-        else:  # if file not exist, prompt user for token
-            UN_TOKEN = input("Please enter your UN API token: ")
 
     # Get fertility rates if not provided
     if fert_rates is None:

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -27,17 +27,6 @@ if os.access(OUTPUT_DIR, os.F_OK) is False:
     os.makedirs(OUTPUT_DIR)
 
 
-# UN data API token
-# global UN_TOKEN
-# # UN_TOKEN = None
-# global UN_TOKEN
-# Check for a file named "un_api_token.txt" in the current directory
-# if os.path.exists("./ogusa/un_api_token.txt"):
-#     with open("un_api_token.txt", "r") as file:
-#         UN_TOKEN = file.read().strip()
-# else:  # if file not exist, prompt user for token
-#     UN_TOKEN = input("Please enter your UN API token: ")
-
 """
 ------------------------------------------------------------------------
 Define functions
@@ -188,10 +177,6 @@ def get_fert(
     df = get_un_data(
         "68", country_id=country_id, start_year=start_year, end_year=end_year
     )
-    if download_path:
-        df.to_csv(
-            os.path.join(download_path, "raw_fert_data_UN.csv"), index=False
-        )
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -278,10 +263,6 @@ def get_mort(
     df = get_un_data(
         "80", country_id=country_id, start_year=start_year, end_year=end_year
     )
-    if download_path:
-        df.to_csv(
-            os.path.join(download_path, "raw_mort_data_UN.csv"), index=False
-        )
     # CLean and rebin data
     for y in range(start_year, end_year + 1):
         df_y = df[(df.age >= min_age) & (df.age <= max_age) & (df.year == y)]
@@ -452,10 +433,6 @@ def get_pop(
             end_year=end_year
             + 2,  # note go to + 2 because needed to infer immigration for end_year
         )
-        if download_path:
-            pop_data.to_csv(
-                os.path.join(download_path, "raw_pop_data_UN.csv"), index=False
-            )
         # CLean and rebin data
         for y in range(start_year, end_year + 2):
             pop_data_sample = pop_data[

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -90,7 +90,7 @@ def get_un_data(
 
     # get data from url
     payload = {}
-    headers = {"Authorization": UN_TOKEN}
+    headers = {"Authorization": "Bearer " + UN_TOKEN}
     response = get_legacy_session().get(target, headers=headers, data=payload)
     # Check if the request was successful before processing
     if response.status_code == 200:
@@ -111,13 +111,35 @@ def get_un_data(
         df = df[df.age < 100]  # need to drop 100+ age category
     else:
         # Read from UN GH Repo:
-        # TODO: put code to do this here...
+        print(
+            f"Failed to retrieve population data from UN. Reading " +
+            " from https://github.com/EAPD-DRB/Population-Data " +
+            "instead of UN WPP API"
+        )
+        country_dict = {
+            "840": "USA",
+            "710": "ZAF",
+            "458": "MYS",
+            "356": "IND",
+            "826": "UK"
+        }
+        un_variable_dict = {
+            "68": "fertility_rates",
+            "80": "mortality_rates",
+            "47": "population"
+        }
+        country = country_dict[country_id]
+        variable = un_variable_dict[variable_code]
+        url = "https://raw.githubusercontent.com/EAPD-DRB/Population-Data/main/Data/{c}/UN_{v}_data.csv".format(c=country, v=variable)
+        df = pd.read_csv(url)
+        # keep just the years requested
+        df = df[(df.year >= start_year) & (df.year <= end_year)]
 
         # Do we still want to keep the status code for failures?
         # print(
         #     f"Failed to retrieve population data. HTTP status code: {response.status_code}"
         # )
-        assert False
+        # assert False
 
     return df
 

--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -806,7 +806,6 @@ def txfunc_est(
             phi1_init = 1.0
             phi2_init = 1.0
             params_init = np.array([phi0_init, phi1_init, phi2_init])
-        print("Initial phi0, phi1, phi2: ", params_init)
         tx_objs = (
             np.array([None]),
             X,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.11.7",
+    version="0.11.8",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -52,6 +52,8 @@ def test_get_pop_objs_read_UN_data():
         GraphDiag=False,
     )
 
+    assert isinstance(pop_dict, dict)
+
 
 def test_get_pop_objs():
     """
@@ -286,6 +288,8 @@ def test_get_imm_rates():
         mort_rates=mort_rates,
         infmort_rates=infmort_rates,
         pop_dist=pop_dist,
+        start_year=2024,
+        end_year=2025,
         graph=True,
     )
     assert imm_rates.shape[1] == S


### PR DESCRIPTION
This PR updates the `demographics.py` module for updates in the UN WPP data portal API, which now requires users to authenticate with an API token.

The PR:
1) Changes the calls to the API to download multiple years at a time, which significantly reduces the number of API calls (Issue #935)
2) Has `demographics.py` look for a file named `un_api_token.txt` in the current directory, and if not there, prompts the user to enter their API token in the command line (Issue #931).
3) Add functionality to read in cached files, pulling the years of data one wants from them. [NOT YET STARTED]