### PR TITLE
Fix to `demographics.py` for case of no token prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.9] - 2024-06-12 01:00:00
+
+### Added
+
+- Update `demographics.py` in the case input prompt not work.
+- Add new utility to dump the parameters to a JSON file
+
+
 ## [0.11.8] - 2024-06-09 01:00:00
 
 ### Added

--- a/docs/book/content/api/utils.rst
+++ b/docs/book/content/api/utils.rst
@@ -17,9 +17,9 @@ ogcore.utils
   :members: init_poolmanager
 
 .. automodule:: ogcore.utils
-  :members: mkdirs, pct_diff_func, convex_combo, read_file,
+  :members: mkdirs, pct_diff_func, convex_combo,
     pickle_file_compare, comp_array, comp_scalar, dict_compare,
     to_timepath_shape, get_initial_path, safe_read_pickle, rate_conversion,
     save_return_table, print_progress, fetch_files_from_web, not_connected,
     avg_by_bin, extrapolate_arrays, get_legacy_session, shift_bio_clock,
-    pct_change_unstationarized
+    pct_change_unstationarized, param_dump_json

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.11.8"
+__version__ = "0.11.9"

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -71,12 +71,15 @@ def get_un_data(
         with open(os.path.join("un_api_token.txt"), "r") as file:
             UN_TOKEN = file.read().strip()
     else:  # if file not exist, prompt user for token
-        UN_TOKEN = input(
-            "Please enter your UN API token (press return if you do not have one): "
-        )
-        # write the UN_TOKEN to a file to find in the future
-        with open(os.path.join("un_api_token.txt"), "w") as file:
-            file.write(UN_TOKEN)
+        try:
+            UN_TOKEN = input(
+                "Please enter your UN API token (press return if you do not have one): "
+            )
+            # write the UN_TOKEN to a file to find in the future
+            with open(os.path.join("un_api_token.txt"), "w") as file:
+                file.write(UN_TOKEN)
+        except EOFError:
+            UN_TOKEN = ""
 
     # get data from url
     payload = {}

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -1,10 +1,8 @@
 import os
 import numpy as np
 import scipy.interpolate as si
-import pkg_resources
 import paramtools
-
-# import ogcore
+import ogcore
 from ogcore import elliptical_u_est
 from ogcore.utils import rate_conversion, extrapolate_arrays
 from ogcore.constants import BASELINE_DIR
@@ -35,7 +33,7 @@ class Specifications(paramtools.Parameters):
         self.num_workers = num_workers
 
         # put OG-Core version in parameters to save for reference
-        self.ogcore_version = pkg_resources.get_distribution("ogcore").version
+        self.ogcore_version = ogcore.__version__
 
         # does cheap calculations to find parameter values
         self.initialize()

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -12,6 +12,7 @@ from scipy.interpolate import CubicSpline
 import pickle
 import urllib3
 import ssl
+import json
 
 EPSILON = 1e-10  # tolerance or comparison functions
 
@@ -1274,3 +1275,42 @@ def pct_change_unstationarized(
         )
 
     return pct_changes
+
+
+def param_dump_json(p, path=None):
+    """
+    This function creates a JSON file with the model parameters of the
+    format used for the default_parameters.json file.
+
+    Args:
+        p (OG-Core Specifications class): model parameters object
+        path (string): path to save JSON file to
+
+    Returns:
+        JSON (string): JSON on model parameters
+    """
+    converted_data = {}
+    spec = p.specification(meta_data=False, include_empty=True, serializable=True, use_state=True)
+    for key in p.keys():
+        val = dict(spec[key][0])['value']
+        if isinstance(val, np.ndarray):
+            converted_data[key] = val.tolist()
+        else:
+            converted_data[key] = val
+
+    # Parameters that need to be turned into annual rates for default_parameters.json
+    # g_y_annual
+    # beta_annual
+    # delta_annual
+    # delta_tau_annual
+    # delta_g_annual
+    # world_int_rate_annual
+
+    # Convert to JSON string
+    json_str = json.dumps(converted_data, indent=4)
+
+    if path is not None:
+        with open(path, "w") as f:
+            f.write(json_str)
+    else:
+        return json_str

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -1290,9 +1290,11 @@ def param_dump_json(p, path=None):
         JSON (string): JSON on model parameters
     """
     converted_data = {}
-    spec = p.specification(meta_data=False, include_empty=True, serializable=True, use_state=True)
+    spec = p.specification(
+        meta_data=False, include_empty=True, serializable=True, use_state=True
+    )
     for key in p.keys():
-        val = dict(spec[key][0])['value']
+        val = dict(spec[key][0])["value"]
         if isinstance(val, np.ndarray):
             converted_data[key] = val.tolist()
         else:

--- a/ogcore/utils.py
+++ b/ogcore/utils.py
@@ -5,13 +5,11 @@ import requests
 from zipfile import ZipFile
 import urllib
 from tempfile import NamedTemporaryFile
-from io import BytesIO, StringIO
+from io import BytesIO
 import numpy as np
 import pandas as pd
 from scipy.interpolate import CubicSpline
 import pickle
-from pkg_resources import resource_stream, Requirement
-import importlib.resources
 import urllib3
 import ssl
 
@@ -76,28 +74,6 @@ def convex_combo(var1, var2, nu):
     """
     combo = nu * var1 + (1 - nu) * var2
     return combo
-
-
-def read_file(path, fname):
-    """
-    Read the contents of 'path'. If it does not exist, assume the file
-    is installed in a .egg file, and adjust accordingly.
-
-    Args:
-        path (str): path name for new directory
-        fname (str): filename
-
-    Returns:
-        file contents (str)
-
-    """
-
-    if not os.path.exists(os.path.join(path, fname)):
-        buf = resource_stream("ogcore", fname)
-        _bytes = buf.read()
-        return StringIO(_bytes.decode("utf-8"))
-    else:
-        return open(os.path.join(path, fname))
 
 
 def pickle_file_compare(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.11.8",
+    version="0.11.9",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -1,6 +1,7 @@
 """
 Tests of parameter_plots.py module
 """
+
 import pytest
 import os
 import sys

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -1,8 +1,6 @@
 """
 Tests of parameter_plots.py module
 """
-
-from tracemalloc import start
 import pytest
 import os
 import sys

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,28 +58,6 @@ def test_convex_combo():
     assert np.allclose(expected, combo)
 
 
-def test_read_file():
-    """
-    Test of utils.read_file() function
-    """
-    path = os.path.join(CUR_PATH, "test_io_data")
-    fname = "SS_fsolve_inputs.pkl"
-    bytes_data = utils.read_file(path, fname)
-
-    assert isinstance(bytes_data, io.TextIOWrapper)
-
-
-def test_read_file_from_egg():
-    """
-    Test of utils.read_file() function, case of reading file from .egg
-    """
-    path = os.path.join(CUR_PATH)
-    fname = "default_parameters.json"
-    bytes_data = utils.read_file(path, fname)
-
-    assert isinstance(bytes_data, io.StringIO)
-
-
 def test_pickle_file_compare():
     """
     Test of utils.pickle_file_compare() function
@@ -947,3 +925,24 @@ def test_pct_change_unstationarized(p1, p2, expected):
     for key in pct_change.keys():
         print("Checking ", key)
         assert np.allclose(pct_change[key], expected[key])
+
+
+def test_param_dump_json():
+    """
+    Test of the param_dump_json function
+    """
+    p = Specifications()
+    j_str = utils.param_dump_json(p)
+    assert isinstance(j_str, str)
+
+
+def test_param_dump_json_save(tempdir):
+    """
+    Test of the param_dump_json function
+    """
+    p = Specifications()
+    utils.param_dump_json(p, path=os.path.join(tempdir, "test.json"))
+    # read in file
+    with open(os.path.join(tempdir, "test.json"), "r") as f:
+        j_str = f.read()
+    assert isinstance(j_str, str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -936,13 +936,13 @@ def test_param_dump_json():
     assert isinstance(j_str, str)
 
 
-def test_param_dump_json_save(tempdir):
+def test_param_dump_json_save(tmpdir):
     """
     Test of the param_dump_json function
     """
     p = Specifications()
-    utils.param_dump_json(p, path=os.path.join(tempdir, "test.json"))
+    utils.param_dump_json(p, path=os.path.join(tmpdir, "test.json"))
     # read in file
-    with open(os.path.join(tempdir, "test.json"), "r") as f:
+    with open(os.path.join(tmpdir, "test.json"), "r") as f:
         j_str = f.read()
     assert isinstance(j_str, str)


### PR DESCRIPTION
This PR fixes an issue with the recently updated `demographics.py`. When working with the module directly, users were prompted for a token.  But when this function is called through other packages, this prompt doesn't seem to always appear.  In case that happens, a `try` and `except` statement has been added so that even if the input prompt is not given, you the demographics still runs, resorting the the `Population-Data` repo.

In addition, a new utility is added that allows users to dump all the parameters from an instance of the `Specifications` class object into a JSON string.  Among other uses, this makes it easy to create JSON files for the default parameters of different calibrations of OG-Core.