### PR TITLE
Update documentation of `demographics.py`

### DIFF
--- a/docs/book/content/api/demographics.rst
+++ b/docs/book/content/api/demographics.rst
@@ -1,0 +1,13 @@
+.. _demographics:
+
+Demographics Functions
+=======================
+
+**demographics.py modules**
+
+ogcore.demographics
+------------------------------------------
+
+.. automodule:: ogcore.demographics
+  :members: get_un_data, get_fert, get_mort, get_pop, pop_rebin, get_imm_rates,
+            immsolve, get_pop_objs, pre_pop_solve

--- a/docs/book/content/api/public_api.rst
+++ b/docs/book/content/api/public_api.rst
@@ -12,6 +12,7 @@ There is also a link to the source code for each documented member.
    :maxdepth: 1
 
    aggregates
+   demographics
    elliptical_u_est
    execute
    firm

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -115,6 +115,8 @@ def get_un_data(
             "458": "MYS",
             "356": "IND",
             "826": "UK",
+            "360": "IDN",
+            "608": "PHL",
         }
         un_variable_dict = {
             "68": "fertility_rates",


### PR DESCRIPTION
This PR adds `demographics.py` to the API docs.  It also adds to the list of countries one can pull data from the UN [Population-Data repo](https://github.com/EAPD-DRB/Population-Data).