### PR TITLE
Fix bug in the `baseline_spending=True` parameterization

### DIFF
--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -665,9 +665,8 @@ def run_TPI(p, client=None):
         D_f = np.zeros(p.T + p.S)
     else:
         if p.baseline_spending:
-            TR = TRbaseline
-            G = Gbaseline
-            G[p.T :] = ss_vars["Gss"]
+            TR = np.concatenate((TRbaseline[:p.T], np.ones(p.S) * ss_vars["TR_ss"]))
+            G = np.concatenate((Gbaseline[:p.T], np.ones(p.S) * ss_vars["Gss"]))
         else:
             TR = p.alpha_T * Y
             G = np.ones(p.T + p.S) * ss_vars["Gss"]

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -665,8 +665,12 @@ def run_TPI(p, client=None):
         D_f = np.zeros(p.T + p.S)
     else:
         if p.baseline_spending:
-            TR = np.concatenate((TRbaseline[:p.T], np.ones(p.S) * ss_vars["TR_ss"]))
-            G = np.concatenate((Gbaseline[:p.T], np.ones(p.S) * ss_vars["Gss"]))
+            TR = np.concatenate(
+                (TRbaseline[: p.T], np.ones(p.S) * ss_vars["TR_ss"])
+            )
+            G = np.concatenate(
+                (Gbaseline[: p.T], np.ones(p.S) * ss_vars["Gss"])
+            )
         else:
             TR = p.alpha_T * Y
             G = np.ones(p.T + p.S) * ss_vars["Gss"]


### PR DESCRIPTION
In PR #880, all TPI output arrays were cast as have a length of `T` in the time dimension.

This posed an error for the case of `baseline_spending=True`, which was looking for aggregate transfers (`TR`) to be of length `T+S`.  This PR fixes that error.