### PR TITLE
Updated g_y_annual min to 0.08 in default_parameters.json

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -40,7 +40,7 @@
         "validators": {
             "range": {
                 "min": -0.01,
-                "max": 0.04
+                "max": 0.08
             }
         }
     },


### PR DESCRIPTION
This PR updates the `g_y_annual` minimum value in `default_parameters.json` to 0.08.

cc: @jdebacker 