### PR TITLE
UBI and `alpha_I` parameter updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.16] - 2024-08-13 12:00:00
+
+### Added
+
+- Description of `alpha_I` in docs
+- Updates valide range of the nominal UBI parameters
+
+### Bug Fix
+
+- Extrapolate `alpha_I`
+- Ensure `alpha_I` shape conforms in `TPI.py`
+- Fix formatting of labels in `constants.py`
+
+-
 ## [0.11.15] - 2024-07-30 12:00:00
 
 ### Bug Fix
@@ -282,6 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version [0.7.0] on August 30, 2021 was the first time that the OG-USA repository was detached from all of the core model logic, which was named OG-Core. Before this version, OG-USA was part of what is now the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository. In the next version of OG-USA, we adjusted the version numbering to begin with 0.1.0. This initial version of 0.7.0, was sequential from what OG-USA used to be when the OG-Core project was called OG-USA.
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
+[0.11.16]: https://github.com/PSLmodels/OG-Core/compare/v0.11.15...v0.11.16
 [0.11.15]: https://github.com/PSLmodels/OG-Core/compare/v0.11.14...v0.11.15
 [0.11.14]: https://github.com/PSLmodels/OG-Core/compare/v0.11.13...v0.11.14
 [0.11.13]: https://github.com/PSLmodels/OG-Core/compare/v0.11.11...v0.11.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.17] - 2024-08-14 12:00:00
+## [0.11.17] - 2024-08-18 12:00:00
 
 ### Added
 
@@ -14,11 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fix
 
-- Extrapolate `alpha_I`
+- Extrapolate `alpha_I` in `parameters.py`
 - Ensure `alpha_I` shape conforms in `TPI.py`
 - Fix formatting of labels in `constants.py`
-
--
 
 ## [0.11.16] - 2024-08-10 12:00:00
 

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -593,7 +593,7 @@ def run_TPI(p, client=None):
     if p.baseline_spending:
         I_g[: p.T] = Ig_baseline[: p.T]
     else:
-        I_g = fiscal.get_I_g(Y[:p.T], p.alpha_I[:p.T])
+        I_g = fiscal.get_I_g(Y[: p.T], p.alpha_I[: p.T])
     if p.baseline:
         K_g0 = p.initial_Kg_ratio * Y[0]
     else:
@@ -945,7 +945,7 @@ def run_TPI(p, client=None):
             B[: p.T], K_demand_open_vec.sum(-1), D_d[: p.T], p.zeta_K[: p.T]
         )
         if not p.baseline_spending:
-            I_g = fiscal.get_I_g(Y[:p.T], p.alpha_I[:p.T])
+            I_g = fiscal.get_I_g(Y[: p.T], p.alpha_I[: p.T])
         if p.baseline:
             K_g0 = p.initial_Kg_ratio * Y[0]
         K_g = fiscal.get_K_g(K_g0, I_g, p, "TPI")

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -593,7 +593,7 @@ def run_TPI(p, client=None):
     if p.baseline_spending:
         I_g[: p.T] = Ig_baseline[: p.T]
     else:
-        I_g = fiscal.get_I_g(Y, p.alpha_I)
+        I_g = fiscal.get_I_g(Y[:p.T], p.alpha_I[:p.T])
     if p.baseline:
         K_g0 = p.initial_Kg_ratio * Y[0]
     else:
@@ -945,7 +945,7 @@ def run_TPI(p, client=None):
             B[: p.T], K_demand_open_vec.sum(-1), D_d[: p.T], p.zeta_K[: p.T]
         )
         if not p.baseline_spending:
-            I_g = fiscal.get_I_g(Y, p.alpha_I)
+            I_g = fiscal.get_I_g(Y[:p.T], p.alpha_I[:p.T])
         if p.baseline:
             K_g0 = p.initial_Kg_ratio * Y[0]
         K_g = fiscal.get_K_g(K_g0, I_g, p, "TPI")

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.11.15"
+__version__ = "0.11.16"

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -1301,8 +1301,8 @@
         ],
         "validators": {
             "range": {
-                "min": 99e9,
-                "max": -99e9
+                "min": -99e9,
+                "max": 99e9
             }
         }
     },

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -730,7 +730,7 @@
     },
     "alpha_I": {
         "title": "Exogenous fraction of GDP that goes towards government investment in infrastructure (public capital)",
-        "description": "",
+        "description": "Exogenous fraction of GDP that goes towards government investment in infrastructure (public capital)",
         "section_1": "Fiscal Policy Parameters",
         "section_2": "Spending",
         "notes": "",

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -1254,7 +1254,7 @@
         "description": "Dollar (nominal) amount of universal basic income (UBI) per child age 0 through 17.",
         "section_1": "Fiscal Policy Parameters",
         "section_2": "Spending",
-        "notes": "The universal basic income (UBI) per child ages 0 through 17 can range from $0 per year to $7,200 per year (max $600 per month).",
+        "notes": "The universal basic income (UBI) per child ages 0 through 17 can take positive or negative values (e.g., a negative value may be used to implement a head tax).",
         "type": "float",
         "value": [
             {
@@ -1263,8 +1263,8 @@
         ],
         "validators": {
             "range": {
-                "min": 0.0,
-                "max": 7200.0
+                "min": -99e9,
+                "max": 99e9
             }
         }
     },
@@ -1273,7 +1273,7 @@
         "description": "Dollar (nominal) amount of universal basic income (UBI) per adult age 18 to 64.",
         "section_1": "Fiscal Policy Parameters",
         "section_2": "Spending",
-        "notes": "The universal basic income (UBI) per adult age 18 through 64 can range from $0 per year to $18,000 per year ($1,500 per month).",
+        "notes": "The universal basic income (UBI) per adult age 18 through 64 can take positive or negative values (e.g., a negative value may be used to implement a head tax).",
         "type": "float",
         "value": [
             {
@@ -1282,8 +1282,8 @@
         ],
         "validators": {
             "range": {
-                "min": 0.0,
-                "max": 18000.0
+                "min": -99e9,
+                "max": 99e9
             }
         }
     },
@@ -1292,7 +1292,7 @@
         "description": "Dollar (nominal) amount of universal basic income (UBI) per adult age 65 and over.",
         "section_1": "Fiscal Policy Parameters",
         "section_2": "Spending",
-        "notes": "The universal basic income (UBI) per adult age 65 and over can range from $0 per year to $12,000 per year ($1,000 per month).",
+        "notes": "The universal basic income (UBI) per adult age 65 can take positive or negative values (e.g., a negative value may be used to implement a head tax).",
         "type": "float",
         "value": [
             {
@@ -1301,8 +1301,8 @@
         ],
         "validators": {
             "range": {
-                "min": 0.0,
-                "max": 12000.0
+                "min": 99e9,
+                "max": -99e9
             }
         }
     },

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -158,6 +158,7 @@ class Specifications(paramtools.Parameters):
         tp_param_list = [
             "alpha_G",
             "alpha_T",
+            "alpha_I",
             "world_int_rate_annual",
             "adjustment_factor_for_cit_receipts",
             "tau_bq",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.11.15",
+    version="0.11.16",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.11.17",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
-    description="A general equilibribum overlapping generations model for fiscal policy analysis",
+    description="A general equilibrium overlapping generations model for fiscal policy analysis",
     long_description_content_type="text/markdown",
     long_description=longdesc,
     url="https://github.com/PSLmodels/OG-Core/",


### PR DESCRIPTION
This PR does the following:

1. Updates the range for the nominal UBI parameters. These were not well defined for using nominal values in different currencies.  Also, negative values may be useful if one wanted to simulate a head tax.
2. Adds a description of the $\alpha_I$ parameter
3. Updates `parameters.py` to extrapolate the `alpha_I` parameter
4. Ensures that `alpha_I` dimensions conform in time path calculations of `I_g`