### PR TITLE
Allow for compatibility with Python 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -27,7 +27,7 @@ jobs:
           miniforge-variant: Mambaforge
           activate-environment: ogcore-dev
           environment-file: environment.yml
-          python-version: "3.11"
+          python-version: "3.12"
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -25,7 +25,7 @@ jobs:
           miniforge-variant: Mambaforge
           activate-environment: ogcore-dev
           environment-file: environment.yml
-          python-version: "3.11"
+          python-version: "3.12"
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Build package
         run: make pip-package
       - name: Publish a Python distribution to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2024-08-20 12:00:00
+
+### Added
+
+- Support for Python 3.12
+
 ## [0.11.17] - 2024-08-18 12:00:00
 
 ### Added
@@ -302,6 +308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version [0.7.0] on August 30, 2021 was the first time that the OG-USA repository was detached from all of the core model logic, which was named OG-Core. Before this version, OG-USA was part of what is now the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository. In the next version of OG-USA, we adjusted the version numbering to begin with 0.1.0. This initial version of 0.7.0, was sequential from what OG-USA used to be when the OG-Core project was called OG-USA.
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
+[0.12.0]: https://github.com/PSLmodels/OG-Core/compare/v0.11.17...v0.12.0
 [0.11.17]: https://github.com/PSLmodels/OG-Core/compare/v0.11.16...v0.11.17
 [0.11.16]: https://github.com/PSLmodels/OG-Core/compare/v0.11.15...v0.11.16
 [0.11.15]: https://github.com/PSLmodels/OG-Core/compare/v0.11.14...v0.11.15

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogcore-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7
+- python>=3.7.7, <3.13
 - numpy
 - ipython
 - setuptools

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogcore-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7, <3.12
+- python>=3.7.7
 - numpy
 - ipython
 - setuptools

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.11.17"
+__version__ = "0.12.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.11.17",
+    version="0.12.0",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibrium overlapping generations model for fiscal policy analysis",
@@ -21,7 +21,7 @@ setuptools.setup(
         "ogcore": ["default_parameters.json", "OGcorePlots.mplstyle"]
     },
     include_packages=True,
-    python_requires=">=3.7.7",
+    python_requires=">=3.7.7, <3.13",
     install_requires=[
         "numpy",
         "scipy>=1.7.1",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "ogcore": ["default_parameters.json", "OGcorePlots.mplstyle"]
     },
     include_packages=True,
-    python_requires=">=3.7.7, <3.12",
+    python_requires=">=3.7.7",
     install_requires=[
         "numpy",
         "scipy>=1.7.1",

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -22,10 +22,16 @@ if sys.version_info[1] < 11:
     base_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_baseline.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     base_params = utils.safe_read_pickle(
         os.path.join(
             CUR_PATH, "test_io_data", "model_params_baseline_v311.pkl"
+        )
+    )
+else:
+    base_params = utils.safe_read_pickle(
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
         )
     )
 reform_ss = utils.safe_read_pickle(
@@ -38,9 +44,13 @@ if sys.version_info[1] < 11:
     reform_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_reform.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     reform_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_reform_v311.pkl")
+    )
+else:
+    reform_params = utils.safe_read_pickle(
+        os.path.join(CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl")
     )
 reform_taxfunctions = utils.safe_read_pickle(
     os.path.join(CUR_PATH, "test_io_data", "TxFuncEst_reform.pkl")
@@ -147,7 +157,7 @@ def test_plot_aggregates(
         plot_type=plot_type,
         stationarized=stationarized,
         num_years_to_plot=20,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         forecast_data=np.ones(20),
         forecast_units="ones",
         vertical_line_years=vertical_line_years,
@@ -198,7 +208,7 @@ def test_plot_industry_aggregates(
         var_list=["Y_vec"],
         plot_type=plot_type,
         num_years_to_plot=20,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         forecast_data=np.ones(20),
         forecast_units="ones",
         vertical_line_years=vertical_line_years,
@@ -218,7 +228,7 @@ test_data = [
 def test_plot_aggregates_save_fig(tmpdir):
     path = os.path.join(tmpdir, "test_plot.png")
     output_plots.plot_aggregates(
-        base_tpi, base_params, start_year=2023, plot_type="levels", path=path
+        base_tpi, base_params, start_year=int(base_params.start_year), plot_type="levels", path=path
     )
     img = mpimg.imread(path)
 
@@ -228,7 +238,7 @@ def test_plot_aggregates_save_fig(tmpdir):
 def test_plot_aggregates_not_a_type(tmpdir):
     with pytest.raises(AssertionError):
         output_plots.plot_aggregates(
-            base_tpi, base_params, start_year=2023, plot_type="levels2"
+            base_tpi, base_params, start_year=int(base_params.start_year), plot_type="levels2"
         )
 
 
@@ -275,7 +285,7 @@ def test_plot_gdp_ratio(
         base_params,
         reform_tpi=reform_tpi,
         reform_params=reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         plot_type=plot_type,
         vertical_line_years=vertical_line_years,
         plot_title=plot_title,
@@ -289,7 +299,7 @@ def test_plot_gdp_ratio_save_fig(tmpdir):
         base_tpi,
         base_params,
         reform_tpi=reform_tpi,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         reform_params=reform_params,
         path=path,
     )
@@ -304,7 +314,7 @@ def test_ability_bar():
         base_params,
         reform_tpi,
         reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         plot_title=" Test Plot Title",
     )
     assert fig
@@ -317,7 +327,7 @@ def test_ability_bar_save_fig(tmpdir):
         base_params,
         reform_tpi,
         reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         path=path,
     )
     img = mpimg.imread(path)
@@ -374,7 +384,7 @@ def test_tpi_profiles(by_j):
         base_params,
         reform_tpi,
         reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         by_j=by_j,
         plot_title=" Test Plot Title",
     )
@@ -404,7 +414,7 @@ def test_tpi_profiles_save_fig(tmpdir):
         base_params,
         reform_tpi,
         reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         path=path,
     )
     img = mpimg.imread(path)
@@ -515,7 +525,7 @@ def test_inequality_plot(
         base_params,
         reform_tpi=reform_tpi,
         reform_params=reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         ineq_measure=ineq_measure,
         pctiles=pctiles,
         plot_type=plot_type,
@@ -530,7 +540,7 @@ def test_inequality_plot_save_fig(tmpdir):
         base_params,
         reform_tpi=reform_tpi,
         reform_params=reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         path=path,
     )
     img = mpimg.imread(path)

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -50,7 +50,9 @@ elif sys.version_info[1] == 11:
     )
 else:
     reform_params = utils.safe_read_pickle(
-        os.path.join(CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl")
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
+        )
     )
 reform_taxfunctions = utils.safe_read_pickle(
     os.path.join(CUR_PATH, "test_io_data", "TxFuncEst_reform.pkl")
@@ -228,7 +230,11 @@ test_data = [
 def test_plot_aggregates_save_fig(tmpdir):
     path = os.path.join(tmpdir, "test_plot.png")
     output_plots.plot_aggregates(
-        base_tpi, base_params, start_year=int(base_params.start_year), plot_type="levels", path=path
+        base_tpi,
+        base_params,
+        start_year=int(base_params.start_year),
+        plot_type="levels",
+        path=path,
     )
     img = mpimg.imread(path)
 
@@ -238,7 +244,10 @@ def test_plot_aggregates_save_fig(tmpdir):
 def test_plot_aggregates_not_a_type(tmpdir):
     with pytest.raises(AssertionError):
         output_plots.plot_aggregates(
-            base_tpi, base_params, start_year=int(base_params.start_year), plot_type="levels2"
+            base_tpi,
+            base_params,
+            start_year=int(base_params.start_year),
+            plot_type="levels2",
         )
 
 

--- a/tests/test_output_tables.py
+++ b/tests/test_output_tables.py
@@ -10,6 +10,9 @@ import numpy as np
 from ogcore import utils, output_tables
 
 
+# TODO: for dynamic_revenue_decomposition, need to add 3.12 pickle of results
+# for baseline and reform that have M = 1 as the 3.12 pickle file does
+
 # Load in test results and parameters
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 base_ss = utils.safe_read_pickle(
@@ -22,10 +25,16 @@ if sys.version_info[1] < 11:
     base_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_baseline.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     base_params = utils.safe_read_pickle(
         os.path.join(
             CUR_PATH, "test_io_data", "model_params_baseline_v311.pkl"
+        )
+    )
+else:
+    base_params = utils.safe_read_pickle(
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
         )
     )
 reform_ss = utils.safe_read_pickle(
@@ -38,9 +47,13 @@ if sys.version_info[1] < 11:
     reform_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_reform.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     reform_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_reform_v311.pkl")
+    )
+else:
+    reform_params = utils.safe_read_pickle(
+        os.path.join(CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl")
     )
 # add investment tax credit parameter that not in cached parameters
 base_params.inv_tax_credit = np.zeros(
@@ -76,7 +89,7 @@ def test_macro_table(
         base_params,
         reform_tpi=reform_tpi,
         reform_params=reform_params,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         output_type=output_type,
         stationarized=stationarized,
         include_SS=True,
@@ -176,7 +189,7 @@ def test_dynamic_revenue_decomposition(include_business_tax, full_break_out):
         reform_params,
         reform_tpi,
         reform_ss,
-        start_year=2023,
+        start_year=int(base_params.start_year),
         include_business_tax=include_business_tax,
         full_break_out=full_break_out,
     )

--- a/tests/test_output_tables.py
+++ b/tests/test_output_tables.py
@@ -10,9 +10,6 @@ import numpy as np
 from ogcore import utils, output_tables
 
 
-# TODO: for dynamic_revenue_decomposition, need to add 3.12 pickle of results
-# for baseline and reform that have M = 1 as the 3.12 pickle file does
-
 # Load in test results and parameters
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 base_ss = utils.safe_read_pickle(

--- a/tests/test_output_tables.py
+++ b/tests/test_output_tables.py
@@ -53,7 +53,9 @@ elif sys.version_info[1] == 11:
     )
 else:
     reform_params = utils.safe_read_pickle(
-        os.path.join(CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl")
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
+        )
     )
 # add investment tax credit parameter that not in cached parameters
 base_params.inv_tax_credit = np.zeros(

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -17,10 +17,16 @@ if sys.version_info[1] < 11:
     base_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_baseline.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     base_params = utils.safe_read_pickle(
         os.path.join(
             CUR_PATH, "test_io_data", "model_params_baseline_v311.pkl"
+        )
+    )
+else:
+    base_params = utils.safe_read_pickle(
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
         )
     )
 base_taxfunctions = utils.safe_read_pickle(
@@ -36,10 +42,11 @@ if sys.version_info[1] < 11:
 micro_data = utils.safe_read_pickle(
     os.path.join(CUR_PATH, "test_io_data", "micro_data_dict_for_tests.pkl")
 )
-base_params.rho = np.tile(
-    base_params.rho.reshape(1, base_params.S),
-    (base_params.T + base_params.S, 1),
-)
+if base_params.rho.ndim == 1:
+    base_params.rho = np.tile(
+            base_params.rho.reshape(1, base_params.S),
+            (base_params.T + base_params.S, 1),
+        )
 
 
 def test_plot_imm_rates():
@@ -94,13 +101,13 @@ def test_plot_surv_rates_save_fig(tmpdir):
 
 def test_plot_pop_growth():
     fig = parameter_plots.plot_pop_growth(
-        base_params, start_year=2023, include_title=True
+        base_params, start_year=int(base_params.start_year), include_title=True
     )
     assert fig
 
 
 def test_plot_pop_growth_rates_save_fig(tmpdir):
-    parameter_plots.plot_pop_growth(base_params, start_year=2023, path=tmpdir)
+    parameter_plots.plot_pop_growth(base_params, start_year=int(base_params.start_year), path=tmpdir)
     img = mpimg.imread(os.path.join(tmpdir, "pop_growth_rates.png"))
 
     assert isinstance(img, np.ndarray)

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -44,9 +44,9 @@ micro_data = utils.safe_read_pickle(
 )
 if base_params.rho.ndim == 1:
     base_params.rho = np.tile(
-            base_params.rho.reshape(1, base_params.S),
-            (base_params.T + base_params.S, 1),
-        )
+        base_params.rho.reshape(1, base_params.S),
+        (base_params.T + base_params.S, 1),
+    )
 
 
 def test_plot_imm_rates():
@@ -107,7 +107,9 @@ def test_plot_pop_growth():
 
 
 def test_plot_pop_growth_rates_save_fig(tmpdir):
-    parameter_plots.plot_pop_growth(base_params, start_year=int(base_params.start_year), path=tmpdir)
+    parameter_plots.plot_pop_growth(
+        base_params, start_year=int(base_params.start_year), path=tmpdir
+    )
     img = mpimg.imread(os.path.join(tmpdir, "pop_growth_rates.png"))
 
     assert isinstance(img, np.ndarray)

--- a/tests/test_parameter_tables.py
+++ b/tests/test_parameter_tables.py
@@ -16,10 +16,16 @@ if sys.version_info[1] < 11:
     base_params = utils.safe_read_pickle(
         os.path.join(CUR_PATH, "test_io_data", "model_params_baseline.pkl")
     )
-else:
+elif sys.version_info[1] == 11:
     base_params = utils.safe_read_pickle(
         os.path.join(
             CUR_PATH, "test_io_data", "model_params_baseline_v311.pkl"
+        )
+    )
+else:
+    base_params = utils.safe_read_pickle(
+        os.path.join(
+            CUR_PATH, "test_io_data", "model_params_baseline_v312.pkl"
         )
     )
 base_taxfunctions = utils.safe_read_pickle(


### PR DESCRIPTION
This PR updates test files so that the unit tests pass on Python 3.12.  As noted in Issue #889, the OG-Core has run on Python 3.12 for some time.  The update here ensure that we can tests against 3.12 and therefore publish packages compatible with that version of Python.

cc @rickecon 