### PR TITLE
Add setuptools to pip-package in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,5 @@ build-docs:
 
 pip-package:
 	pip install wheel
+	pip install setuptools
 	python setup.py sdist bdist_wheel

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,10 @@ git-pr:
 build-docs:
 	@cd ./docs ; python make_params.py; jb build ./book
 
+format:
+	black . -l 79
+	linecheck . --fix
+
 pip-package:
 	pip install wheel
 	pip install setuptools


### PR DESCRIPTION
This PR adds `pip install setuptools` to the `pip-package` section of `Makefile`. This is because the `publish_to_pypi.yml` GH Action stopped working when we moved to Python 3.12 in PR #969. The error traceback on this GH Action that only runs when a PR is merged is the following. I found in this description of [What's new in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html) that this version stopped including the `setuptools` and `wheel` packages. For this reason, I think the solution is to just add the `pip install setuptools` line to the `pip-package` section of `Makefile`. Whether this works can only be tested by merging this PR and seeing if the `ogcore` Python package automatically loads to PyPI.org afterward.
```
Run make pip-package
  make pip-package
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.1[2](https://github.com/PSLmodels/OG-Core/actions/runs/10479180751/job/29024292988#step:5:2).4/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/[3](https://github.com/PSLmodels/OG-Core/actions/runs/10479180751/job/29024292988#step:5:3).12.4/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.[4](https://github.com/PSLmodels/OG-Core/actions/runs/10479180751/job/29024292988#step:5:4)/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.4/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.4/x64/lib
pip install wheel
Collecting wheel
  Downloading wheel-0.44.0-py3-none-any.whl.metadata (2.3 kB)
Downloading wheel-0.44.0-py3-none-any.whl (67 kB)
Installing collected packages: wheel
Successfully installed wheel-0.44.0
python setup.py sdist bdist_wheel
Traceback (most recent call last):
  File "/home/runner/work/OG-Core/OG-Core/setup.py", line 1, in <module>
    import setuptools
ModuleNotFoundError: No module named 'setuptools'
make: *** [Makefile:7[5](https://github.com/PSLmodels/OG-Core/actions/runs/10479180751/job/29024292988#step:5:5): pip-package] Error 1
Error: Process completed with exit code 2.
```
@jdebacker 