### PR TITLE
Add Korea to demographics dict

### DIFF
--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -115,6 +115,7 @@ def get_un_data(
             "826": "UK",
             "360": "IDN",
             "608": "PHL",
+            "410": "KOR",
         }
         un_variable_dict = {
             "68": "fertility_rates",


### PR DESCRIPTION
This PR updates `demographics.py` so that it can look to the [UN Population Data repo](https://github.com/EAPD-DRB/Population-Data) for the country of Korea.