### PR TITLE
Fix typo in _toc.yml

### DIFF
--- a/docs/book/_toc.yml
+++ b/docs/book/_toc.yml
@@ -24,7 +24,7 @@ parts:
   chapters:
   - file: content/theory/derivations
   - file: content/intro/parameters
-  file: content/intro/variables
+  - file: content/intro/variables
 - caption: References
   chapters:
   - file: content/OGCore_references


### PR DESCRIPTION
This PR fixes a typo in the documentation `_toc.yml` file.

cc: @jdebacker 