### PR TITLE
Updates to tax function estimation

### DIFF
--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -596,6 +596,8 @@ def txfunc_est(
         output_dir (str): output directory for saving plot files
         graph (bool): whether to plot the estimated functions compared
             to the data
+        params_init (Numpy array): initial values for the parameters
+        global_opt (bool): whether to use global optimization method
 
     Returns:
         (tuple): tax function estimation output:
@@ -802,9 +804,9 @@ def txfunc_est(
         # Need to use a different functional form than for DEP function.
         # '''
         if params_init is None:
-            phi0_init = 1.0
-            phi1_init = 1.0
-            phi2_init = 1.0
+            phi0_init = 0.3
+            phi1_init = 0.3
+            phi2_init = 0.01
             params_init = np.array([phi0_init, phi1_init, phi2_init])
         tx_objs = (
             np.array([None]),
@@ -815,8 +817,7 @@ def txfunc_est(
             tax_func_type,
             rate_type,
         )
-        # bnds = ((1e-12, None), (1e-12, None), (1e-12, None))
-        bnds = ((1e-12, 9999), (1e-12, 9999), (1e-12, 9999))
+        bnds = ((1e-12, 1.0), (1e-12, 1.0), (1e-12, 1.0))
         if global_opt:
             params_til = opt.differential_evolution(
                 wsumsq, bounds=bnds, args=(tx_objs), seed=1

--- a/ogcore/txfunc.py
+++ b/ogcore/txfunc.py
@@ -840,15 +840,16 @@ def txfunc_est(
         # set initial values to parameter estimates
         params_init = np.array([phi0til, phi1til, phi2til])
     elif tax_func_type == "HSV":
-        # '''
-        # Estimate Heathcote, Storesletten, Violante (2017) parameters via
-        # OLS
-        # '''
+        """
+        Estimate Heathcote, Storesletten, Violante (2017) parameters via
+        OLS
+        """
         constant = np.ones_like(income)
         ln_income = np.log(income)
         X_mat = np.column_stack((constant, ln_income))
         Y_vec = np.log(1 - txrates)
-        param_est = np.linalg.inv(X_mat.T @ X_mat) @ X_mat.T @ Y_vec
+        W = np.diag(wgts)
+        param_est = np.linalg.inv(X_mat.T @ W @ X_mat) @ X_mat.T @ W @ Y_vec
         params = np.zeros(numparams)
         if rate_type == "etr":
             ln_lambda_s_hat, minus_tau_s_hat = param_est
@@ -859,16 +860,15 @@ def txfunc_est(
             params[:2] = np.array([lambda_s_hat, -minus_tau_s_hat])
         # Calculate the WSSE
         Y_hat = X_mat @ params
-        # wsse = ((Y_vec - Y_hat) ** 2 * wgts).sum()
-        wsse = ((Y_vec - Y_hat) ** 2).sum()
+        wsse = ((Y_vec - Y_hat) ** 2 * wgts).sum()
         obs = df.shape[0]
         params_to_plot = params
     elif tax_func_type == "linear":
-        # '''
-        # For linear rates, just take the mean ETR or MTR by age-year.
-        # Can use DEP form and set all parameters except for the shift
-        # parameter to zero.
-        # '''
+        """
+        For linear rates, just take the mean ETR or MTR by age-year.
+        Can use DEP form and set all parameters except for the shift
+        parameter to zero.
+        """
         params = np.zeros(numparams)
         wsse = 0.0
         obs = df.shape[0]


### PR DESCRIPTION
This PR updates `txfunc.py`, in particular for the estimation of the `GS` and `HSV` functions.  Specifically:

* Sampling weights are added to the estimation of tax functions of the`HSV` form (addressing Issue #1027).
* The estimation of functions of the `GS` form are improved by (1) changing the initial guesses to more reasonable value and (2) setting stricter bounds so the parameters do not get out of reasonable ranges in the minimizer.

Updated GS functions (2025 current law, TMD data):
![gs_etr_new](https://github.com/user-attachments/assets/14f6b215-1cdb-482a-8b80-45a617db474a)

Updated HSV functions (2025 current law, TMD data):
![hsv_etr_new](https://github.com/user-attachments/assets/12d16a7f-3da1-46f1-99a7-fc577d5991a6)
