### PR TITLE
Fix remittances in aggregate resource constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.14.4] - 2025-06-23 18:00:00
+
+### Added
+
+- Fixes the sign error on the remittances `RM` term in `aggregates.py`, `resource_constraint()` function.
+- Added a test with positive remittances to `test_aggregates.py`, `test_resource_constraint()` function.
+
 ## [0.14.3] - 2025-04-25 10:00:00
 
 ### Added
@@ -383,6 +390,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.14.4]: https://github.com/PSLmodels/OG-Core/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/PSLmodels/OG-Core/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/PSLmodels/OG-Core/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/PSLmodels/OG-Core/compare/v0.14.0...v0.14.1

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.14.3"
+__version__ = "0.14.4"

--- a/ogcore/aggregates.py
+++ b/ogcore/aggregates.py
@@ -526,7 +526,7 @@ def resource_constraint(Y, C, G, I_d, I_g, net_capital_flows, RM):
         \text{rc_error} &= \hat{Y}_t - \hat{C}_t -
       \Bigl(e^{g_y}\bigl[1 + \tilde{g}_{n,t+1}\bigr]\hat{K}^d_{t+1} -
       \hat{K}^d_t\Bigr) - \delta\hat{K}_t - \hat{G}_t - \hat{I}_{g,t} ... \\
-        &\qquad -\: \hat{\text{net capital outflows}}_t - \hat{RM}_t
+        &\qquad -\: \hat{\text{net capital outflows}}_t + \hat{RM}_t
       \end{split}
 
     Args:
@@ -542,7 +542,7 @@ def resource_constraint(Y, C, G, I_d, I_g, net_capital_flows, RM):
         rc_error (array_like): error in the resource constraint
 
     """
-    rc_error = Y - C - I_d - I_g - G - net_capital_flows - RM
+    rc_error = Y - C - I_d - I_g - G - net_capital_flows + RM
 
     return rc_error
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.14.3",
+    version="0.14.4",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibrium overlapping generations model for fiscal policy analysis",

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1699,21 +1699,60 @@ def test_get_r_p(r, r_gov, p_m, K_vec, K_g, D, MPKg_vec, method, expected):
     assert np.allclose(r_p_test, expected)
 
 
-def test_resource_constraint():
+test_data_rc = [
+    (
+        np.array([48, 55, 2, 99, 8]),  # Y
+        np.array([33, 44, 0.4, 55, 6]),  # C
+        np.array([4, 5, 0.01, 22, 0]),  # G
+        np.array([20, 5, 0.6, 10, 1]),  # I_d
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0]),  # I_g
+        np.array([0.1, 0, 0.016, -1.67, -0.477]),  # net_capital_flows
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0]),  # RM1
+        np.array([-9.1, 1, 0.974, 13.67, 1.477]),  # expected1
+    ),
+    (
+        np.array([48, 55, 2, 99, 8]),  # Y
+        np.array([33, 44, 0.4, 55, 6]),  # C
+        np.array([4, 5, 0.01, 22, 0]),  # G
+        np.array([20, 5, 0.6, 10, 1]),  # I_d
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0]),  # I_g
+        np.array([0.1, 0, 0.016, -1.67, -0.477]),  # net_capital_flows
+        np.array([0.0, 0.0, 0.0, 0.0, 0.03]),  # RM2
+        np.array([-9.1, 1, 0.974, 13.67, 1.507]),  # expected2
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "Y,C,G,I_d,I_g,net_capital_flows,RM,expected",
+    test_data_rc,
+    ids=[
+        "RM=0, M=5",
+        "RM>0, M=5"
+    ],
+)
+def test_resource_constraint(
+        Y, C, G, I_d, I_g, net_capital_flows, RM, expected
+    ):
     """
     Test resource constraint equation.
     """
-    Y = np.array([48, 55, 2, 99, 8])
-    C = np.array([33, 44, 0.4, 55, 6])
-    G = np.array([4, 5, 0.01, 22, 0])
-    I_d = np.array([20, 5, 0.6, 10, 1])
-    I_g = np.zeros_like(I_d)
-    net_capital_flows = np.array([0.1, 0, 0.016, -1.67, -0.477])
-    RM = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
-    expected = np.array([-9.1, 1, 0.974, 13.67, 1.477])
+    # Y = np.array([48, 55, 2, 99, 8])
+    # C = np.array([33, 44, 0.4, 55, 6])
+    # G = np.array([4, 5, 0.01, 22, 0])
+    # I_d = np.array([20, 5, 0.6, 10, 1])
+    # I_g = np.zeros_like(I_d)
+    # net_capital_flows = np.array([0.1, 0, 0.016, -1.67, -0.477])
+    # RM1 = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+    # expected1 = np.array([-9.1, 1, 0.974, 13.67, 1.477])
     test_RC = aggr.resource_constraint(
         Y, C, G, I_d, I_g, net_capital_flows, RM
     )
+    # RM2 = np.array([0.0, 0.0, 0.0, 0.0, 0.03])
+    # expected2 = np.array([-9.1, 1, 0.974, 13.67, 1.477])
+    # test_RC2 = aggr.resource_constraint(
+    #     Y, C, G, I_d, I_g, net_capital_flows, RM2
+    # )
 
     assert np.allclose(test_RC, expected)
 

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1726,14 +1726,11 @@ test_data_rc = [
 @pytest.mark.parametrize(
     "Y,C,G,I_d,I_g,net_capital_flows,RM,expected",
     test_data_rc,
-    ids=[
-        "RM=0, M=5",
-        "RM>0, M=5"
-    ],
+    ids=["RM=0, M=5", "RM>0, M=5"],
 )
 def test_resource_constraint(
-        Y, C, G, I_d, I_g, net_capital_flows, RM, expected
-    ):
+    Y, C, G, I_d, I_g, net_capital_flows, RM, expected
+):
     """
     Test resource constraint equation.
     """


### PR DESCRIPTION
This PR fixes a sign error typo on the remittances term in the aggregate resource constraint.
- Fixes the sign error on the `RM` term in `aggregates.py`, `resource_constraint()` function.
- Added a test with positive remittances to `test_aggregates.py`, `test_resource_constraint()` function.

I also ran a test execution script that took the baseline specification from `run_ogcore_example.py` and added the Philippine remittance calibration specification.

```python
og_spec = {
    "frisch": 0.41,
    "start_year": START_YEAR,
    "cit_rate": [[0.21]],
    "debt_ratio_ss": 1.0,
    "alpha_T": alpha_T.tolist(),
    "alpha_G": alpha_G.tolist(),
    "initial_guess_r_SS": 0.04,
    "alpha_RM_1": 0.083,
    "alpha_RM_T": 0.083,
    "g_RM": [0.03]
}
```

This specification ran perfectly in both the SS and TPI computations.

**Steady-state equilibrium computation output**
```
GE loop errors = [1.6329923524516232e-12, 1.6438933547746615e-12, 1.6328050023162177e-11, 0.0, -8.956169139651138e-13, 6.089226345373788e-13, 7.715633687510604e-13, 2.642833868415906e-12, 5.010644676950449e-13, -4.038141349083091e-13, 2.54230664298305e-12, -3.54231401156202e-13, -8.060219158778636e-14, 1.0793865801161928e-12]
Iteration: 1  Distance: 8.828619615632333e-11
SS debt = 0.6165550819911706, 0.007838787715122064
IO: (1, 1), C: (1,)
Foreign debt holdings = 0.24662203279646824
Foreign capital holdings = 0.036461601788039456
resource constraint: [-9.03652153e-14]
Checking constraints on capital, labor, and consumption.
	There were no violations of the constraints on labor  supply.
	There were no violations of the constraints on  consumption.
Maximum error in labor FOC = 3.552713678800501e-13
Maximum error in savings FOC = 3.7347902548390266e-13
JUST SAVED SS output to  /Users/richardevans/Docs/Economics/OSE/OG/OG-Core/run_examples/OG-Core-RM-PHL/OUTPUT_BASELINE/SS/SS_vars.pkl
```

**Transition path equilibrium computation output** (24 min 0 sec)
```
Maximum debt ratio:  1.493724944224733
w diff: 8.17279948162053e-07, -2.137170427296553e-07
r diff: 3.129908086180189e-08, -1.232675157711305e-07
r_p diff: -1.1151960258026783e-09, -1.2603517966780498e-07
p_m diff: 0.0, 0.0
BQ diff: 1.168565591166959e-07, -1.7487559615669834e-08
TR diff: 4.597033187447863e-08, -2.91214937969686e-07
Iteration: 21
	Distance: 6.188478319354992e-06
Max absolute value resource constraint error: 7.955282764621208e-07
Checking time path for violations of constraints.
Max Euler error, savings: 3.970657136420641e-12
Max Euler error labor supply: 9.401368572525826e-13
Time path iteration complete.
It took 1440.3786189556122 seconds to get that part done.
run time =  1440.3799769878387
```

Merging this PR will resolve and close Issue #1035 and will allow us update the remittances calibration in the OG-PHL repository (see OG-PHL [Issue #40](https://github.com/EAPD-DRB/OG-PHL/issues/40) and [PR #39 thread](https://github.com/EAPD-DRB/OG-PHL/pull/39)).

cc: @jdebacker