### PR TITLE
Increase the maximum for init_guess_TR_SS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.14.5] - 2025-07-08 22:00:00
+
+### Added
+
+- Increases the maximum value of `initial_guess_TR_SS` in `default_parameters.json`
+
 ## [0.14.4] - 2025-06-23 18:00:00
 
 ### Added
@@ -390,6 +396,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.14.5]: https://github.com/PSLmodels/OG-Core/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/PSLmodels/OG-Core/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/PSLmodels/OG-Core/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/PSLmodels/OG-Core/compare/v0.14.1...v0.14.2

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.14.4"
+__version__ = "0.14.5"

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -4435,7 +4435,7 @@
     },
     "initial_guess_TR_SS": {
         "title": "Initial guess of TR for the SS solution",
-        "description": "Initial guess of TR for the SS solution.",
+        "description": "Initial guess of TR for the SS solution. This value is in model units and can therefore be any large positive number. We may have to adjust the maximum for this parameter from time to time.",
         "section_1": "Model Solution Parameters",
         "notes": "",
         "type": "float",
@@ -4447,7 +4447,7 @@
         "validators": {
             "range": {
                 "min": 0.0,
-                "max": 0.2
+                "max": 2.5
             }
         }
     },

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.14.4",
+    version="0.14.5",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibrium overlapping generations model for fiscal policy analysis",


### PR DESCRIPTION
This PR increases the maximum value of `init_guess_TR_SS` in the `default_parameters.json` file. The current maximum is 0.2. However, this variable is in model units and is not a percentage. As such, its values in the SS can be significantly bigger than 0.2. This is the case in OG-PHL. The maximum value of 2.5 to which I changed it is arbitrary. We may need to increase this value from time-to-time.

cc: @jdebacker 