### PR TITLE
Changes to how the parameter object is scattered in dask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.14.7] - 2025-08-21 17:00:00
+
+### Added
+
+- Refactor calls to dask in `SS.py` and `TPI.py`.  See PR [#1048](https://github.com/PSLmodels/OG-Core/pull/1048)
+
 ## [0.14.6] - 2025-08-15 14:00:00
 
 ### Added
@@ -403,6 +409,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.14.7]: https://github.com/PSLmodels/OG-Core/compare/v0.14.6...v0.14.7
 [0.14.6]: https://github.com/PSLmodels/OG-Core/compare/v0.14.5...v0.14.6
 [0.14.5]: https://github.com/PSLmodels/OG-Core/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/PSLmodels/OG-Core/compare/v0.14.3...v0.14.4

--- a/environment.yml
+++ b/environment.yml
@@ -13,9 +13,8 @@ dependencies:
 - dask>=2.30.0
 - dask-core>=2.30.0
 - distributed>=2.30.1
-- paramtools>=0.15.0
+- paramtools>=0.20.0
 - sphinx>=3.5.4
-- marshmallow<4.0.0
 - sphinx-argparse
 - sphinxcontrib-bibtex>=2.0.0
 - sphinx-math-dollar

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -316,12 +316,6 @@ def inner_loop(outer_loop_vars, p, client):
             )
             futures.append(f)
 
-        # print("Futures =")
-        # print(dask_sizeof(futures))  # shows what’s embedded
-        # d = dask.delayed(futures)
-        # d.visualize(rankdir="LR", filename="graph.svg")
-        print("Client link = ", client.dashboard_link)
-
         results = client.gather(futures)
 
     else:

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -218,7 +218,7 @@ def solve_for_j(
             j,
             p_future,
         ),
-        method=p.FOC_root_method,
+        method=p_future.FOC_root_method,
         tol=MINIMIZER_TOL,
     )
 

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -294,7 +294,7 @@ def inner_loop(outer_loop_vars, p, client):
 
     if client:
         # Scatter p only once and only if client not equal None
-        # scattered_p_future = client.scatter(p, broadcast=True)
+        scattered_p_future = client.scatter(p, broadcast=True)
 
         # Launch in parallel with submit (or map)
         futures = []
@@ -1253,15 +1253,6 @@ def run_SS(p, client=None):
             results
 
     """
-
-    # Definte a scattered version of the parameters, p at the module
-    # level so that it can be used in functions called by Dask
-    global scattered_p_future
-    if client:
-        scattered_p_future = client.scatter(p, broadcast=True)
-    else:
-        scattered_p_future = p
-
     # Create list of deviation factors for initial guesses of r and TR
     dev_factor_list = [
         [1.00, 1.0],

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.14.6"
+__version__ = "0.14.7"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.14.6",
+    version="0.14.7",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibrium overlapping generations model for fiscal policy analysis",


### PR DESCRIPTION
This PR makes some changes to how the parameter object is scattered and referenced by dask futures calls in `SS.py` and `TPI.py`.  In particular:

* dask futures are used rather than delayed objects
* Function definitions are not done in a delayed object since they are called with each future
* The `Specifications` object, `p`, is scattered outside of the TPI loop since it's not changed in the while loop (so only need to define once)