### PR TITLE
Centralize logging configuration

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -6,6 +6,7 @@ import dask.multiprocessing
 from ogcore import tax, pensions, household, firm, utils, fiscal
 from ogcore import aggregates as aggr
 from ogcore.constants import SHOW_RUNTIME
+from ogcore import config
 import os
 import warnings
 import logging
@@ -24,15 +25,6 @@ Set flag for enforcement of solution check
 """
 ENFORCE_SOLUTION_CHECKS = True
 
-"""
-Set flag for verbosity
-"""
-VERBOSE = True
-# Configure logging
-log_level = logging.INFO if VERBOSE else logging.WARNING
-logging.basicConfig(
-    level=log_level, format="%(message)s"  # Only show the message itself
-)
 
 
 """
@@ -1240,19 +1232,22 @@ def SS_fsolve(guesses, *args):
     return errors
 
 
-def run_SS(p, client=None):
+def run_SS(p, client=None, verbose=False):
     """
     Solve for steady-state equilibrium of OG-Core.
 
     Args:
         p (OG-Core Specifications object): model parameters
         client (Dask client object): client
+        verbose (bool): if True, set logging to INFO level
 
     Returns:
         output (dictionary): dictionary with steady-state solution
             results
 
     """
+    # Configure logging level based on verbose parameter
+    config.set_logging_level(verbose)
     # Create list of deviation factors for initial guesses of r and TR
     dev_factor_list = [
         [1.00, 1.0],

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -1226,7 +1226,7 @@ def SS_fsolve(guesses, *args):
             + list(error_BQ)
             + [error_TR]
         )
-    logging.info(f"GE loop errors = {errors}")
+    logging.info(f"GE loop errors = {errors:.3e}")
 
     return errors
 

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -26,7 +26,6 @@ Set flag for enforcement of solution check
 ENFORCE_SOLUTION_CHECKS = True
 
 
-
 """
 ------------------------------------------------------------------------
     Define Functions

--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -1226,7 +1226,7 @@ def SS_fsolve(guesses, *args):
             + list(error_BQ)
             + [error_TR]
         )
-    logging.info(f"GE loop errors = {errors:.3e}")
+    logging.info(f"GE loop errors = ", [f"{error:.3e}" for error in errors])
 
     return errors
 

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -18,6 +18,7 @@ import dask.multiprocessing
 from ogcore import tax, utils, household, firm, fiscal
 from ogcore import aggregates as aggr
 from ogcore.constants import SHOW_RUNTIME
+from ogcore import config
 import os
 import warnings
 import logging
@@ -36,15 +37,6 @@ Set flag for enforcement of solution check
 """
 ENFORCE_SOLUTION_CHECKS = True
 
-"""
-Set flag for verbosity
-"""
-VERBOSE = True
-# Configure logging
-log_level = logging.INFO if VERBOSE else logging.WARNING
-logging.basicConfig(
-    level=log_level, format="%(message)s"  # Only show the message itself
-)
 
 
 def get_initial_SS_values(p):
@@ -558,19 +550,22 @@ def inner_loop(guesses, outer_loop_vars, initial_values, ubi, j, ind, p):
     return euler_errors, b_mat, n_mat
 
 
-def run_TPI(p, client=None):
+def run_TPI(p, client=None, verbose=False):
     """
     Solve for transition path equilibrium of OG-Core.
 
     Args:
         p (OG-Core Specifications object): model parameters
         client (Dask client object): client
+        verbose (bool): if True, set logging to INFO level
 
     Returns:
         output (dictionary): dictionary with transition path solution
             results
 
     """
+    # Configure logging level based on verbose parameter
+    config.set_logging_level(verbose)
     # unpack tuples of parameters
     initial_values, ss_vars, theta, baseline_values = get_initial_SS_values(p)
     (B0, b_sinit, b_splus1init, factor, initial_b, initial_n) = initial_values

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -38,7 +38,6 @@ Set flag for enforcement of solution check
 ENFORCE_SOLUTION_CHECKS = True
 
 
-
 def get_initial_SS_values(p):
     """
     Get values of variables for the initial period and the steady state

--- a/ogcore/config.py
+++ b/ogcore/config.py
@@ -1,0 +1,38 @@
+"""
+Centralized configuration for OG-Core logging.
+
+This module provides a centralized way to configure logging levels
+across all OG-Core modules, avoiding circular import issues.
+"""
+
+import logging
+
+VERBOSE = False  # Default value
+
+
+def set_logging_level(verbose=False):
+    """
+    Set the logging level for OG-Core modules.
+    
+    Args:
+        verbose (bool): If True, set logging to INFO level.
+                       If False, set logging to WARNING level.
+    
+    Returns:
+        int: The logging level that was set.
+    """
+    global VERBOSE
+    VERBOSE = verbose
+    level = logging.INFO if verbose else logging.WARNING
+    
+    # Configure the root logger
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    
+    # Also set the ogcore logger specifically
+    logger = logging.getLogger('ogcore')
+    logger.setLevel(level)
+    
+    return level

--- a/ogcore/config.py
+++ b/ogcore/config.py
@@ -13,26 +13,26 @@ VERBOSE = False  # Default value
 def set_logging_level(verbose=False):
     """
     Set the logging level for OG-Core modules.
-    
+
     Args:
         verbose (bool): If True, set logging to INFO level.
                        If False, set logging to WARNING level.
-    
+
     Returns:
         int: The logging level that was set.
     """
     global VERBOSE
     VERBOSE = verbose
     level = logging.INFO if verbose else logging.WARNING
-    
+
     # Configure the root logger
     logging.basicConfig(
         level=level,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
-    
+
     # Also set the ogcore logger specifically
-    logger = logging.getLogger('ogcore')
+    logger = logging.getLogger("ogcore")
     logger.setLevel(level)
-    
+
     return level


### PR DESCRIPTION
- Created `ogcore/config.py` with centralized logging configuration
- Updated `SS.py` and `TPI.py` to use `config.set_logging_level()` with verbose parameter
- Removed `VERBOSE` constants from `SS.py` and `TPI.py` modules
- Main functions now accept verbose parameter instead of using global constant

🤖 Generated with [Claude Code](https://claude.ai/code)