### PR TITLE
Consumption tax liability function

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -951,7 +951,7 @@ def SS_solver(
         np.squeeze(p.e[-1, :, :]),
         p,
     )
-    sales_tax_ss = (p.tau_c[-1, :] * p_i_ss).reshape(p.I, 1, 1) * cssmat
+    sales_tax_ss = tax.cons_tax_liab(cssmat, p_i_ss, p, "SS")
     yss_before_tax_mat = household.get_y(
         r_p_ss, wss, bssmat_s, nssmat, p, "SS"
     )

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -883,9 +883,7 @@ def run_TPI(p, client=None):
             p.e,
             p,
         )
-        sales_tax_mat = (p.tau_c[: p.T, :] * p_i[: p.T, :]).reshape(
-            p.T, p.I, 1, 1
-        ) * c_mat
+        sales_tax_mat = tax.cons_tax_liab(c_mat, p_i, p, "TPI")
         C = aggr.get_C(c_mat, p, "TPI")
 
         c_i = household.get_ci(

--- a/ogcore/aggregates.py
+++ b/ogcore/aggregates.py
@@ -409,8 +409,7 @@ def revenue(
         wealth_tax_revenue = (w_tax_liab * pop_weights).sum()
         bequest_tax_revenue = (bq_tax_liab * pop_weights).sum()
         cons_tax_revenue = (
-            ((p.tau_c[-1, :] * p_i).reshape(p.I, 1, 1) * c).sum(axis=0)
-            * pop_weights
+            tax.cons_tax_liab(c, p_i, p, method) * pop_weights
         ).sum()
         payroll_tax_revenue = p.frac_tax_payroll[-1] * iit_payroll_tax_revenue
     elif method == "TPI":
@@ -429,14 +428,7 @@ def revenue(
         wealth_tax_revenue = (w_tax_liab * pop_weights).sum(1).sum(1)
         bequest_tax_revenue = (bq_tax_liab * pop_weights).sum(1).sum(1)
         cons_tax_revenue = (
-            (
-                ((p.tau_c[: p.T, :] * p_i).reshape(p.T, p.I, 1, 1) * c).sum(
-                    axis=1
-                )
-                * pop_weights
-            )
-            .sum(1)
-            .sum(1)
+            (tax.cons_tax_liab(c, p_i, p, method) * pop_weights).sum(1).sum(1)
         )
         payroll_tax_revenue = (
             p.frac_tax_payroll[: p.T] * iit_payroll_tax_revenue

--- a/ogcore/tax.py
+++ b/ogcore/tax.py
@@ -501,3 +501,21 @@ def bequest_tax_liab(r, b, bq, t, j, method, p):
         T_BQ = p.tau_bq[0] * bq
 
     return T_BQ
+
+
+def cons_tax_liab(c, p_i, p, method="SS"):
+    """
+    Calculates consumption tax liability for each household.
+
+    Args:
+
+    Returns:
+    """
+    if method == "SS":
+        c_tax = ((p.tau_c[-1, :] * p_i).reshape(p.I, 1, 1) * c).sum(axis=0)
+    else:
+        c_tax = ((p.tau_c[: p.T, :] * p_i).reshape(p.T, p.I, 1, 1) * c).sum(
+            axis=1
+        )
+
+    return c_tax

--- a/ogcore/tax.py
+++ b/ogcore/tax.py
@@ -514,8 +514,8 @@ def cons_tax_liab(c, p_i, p, method="SS"):
     if method == "SS":
         c_tax = ((p.tau_c[-1, :] * p_i).reshape(p.I, 1, 1) * c).sum(axis=0)
     else:
-        c_tax = ((p.tau_c[: p.T, :] * p_i).reshape(p.T, p.I, 1, 1) * c).sum(
-            axis=1
-        )
+        c_tax = (
+            (p.tau_c[: p.T, :] * p_i[: p.T, :]).reshape(p.T, p.I, 1, 1) * c
+        ).sum(axis=1)
 
     return c_tax

--- a/ogcore/tax.py
+++ b/ogcore/tax.py
@@ -508,8 +508,17 @@ def cons_tax_liab(c, p_i, p, method="SS"):
     Calculates consumption tax liability for each household.
 
     Args:
+        c (numpy.ndarray): Consumption array. Dimensions depend on the method:
+            - If method == "SS": shape (I, S, J)
+            - If method != "SS": shape (T, I, S, J)
+        p_i (numpy.ndarray): Array of consumption tax rates by good. Shape (I,) or (T, I).
+        p (OG-Core Specifications object): Model parameters, including tax rates and dimensions.
+        method (str, optional): Indicates whether calculation is for steady-state ('SS') or transition path ('TPI'). Default is 'SS'.
 
     Returns:
+        c_tax (numpy.ndarray): Consumption tax liability for each household.
+            - If method == "SS": shape (S, J)
+            - If method != "SS": shape (T, S, J)
     """
     if method == "SS":
         c_tax = ((p.tau_c[-1, :] * p_i).reshape(p.I, 1, 1) * c).sum(axis=0)

--- a/tests/test_TPI.py
+++ b/tests/test_TPI.py
@@ -22,7 +22,7 @@ from ogcore import SS, TPI, utils
 import ogcore.aggregates as aggr
 from ogcore.parameters import Specifications
 
-NUM_WORKERS = min(multiprocessing.cpu_count(), 7)
+NUM_WORKERS = min(multiprocessing.cpu_count(), 4)
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 
 SS_VAR_NAME_MAPPING = {
@@ -146,7 +146,7 @@ VAR_NAME_MAPPING = {
     "tr_path": "tr",
     "ubi_path": "ubi",
     "y_before_tax_mat": "before_tax_income",
-    "tax_path": "hh_taxes",
+    "tax_path": "hh_net_taxes",
     "etr_path": "etr",
     "mtrx_path": "mtrx",
     "mtry_path": "mtry",
@@ -166,7 +166,14 @@ TEST_PARAM_DICT = json.load(
 
 @pytest.fixture(scope="module")
 def dask_client():
-    cluster = LocalCluster(n_workers=NUM_WORKERS, threads_per_worker=2)
+    cluster = LocalCluster(
+        n_workers=NUM_WORKERS,
+        threads_per_worker=2,
+        memory_limit="2GB",
+        timeout="300s",
+        heartbeat_interval="10s",
+        death_timeout="60s",
+    )
     client = Client(cluster)
     yield client
     # teardown

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -1752,3 +1752,32 @@ def test_net_taxes(
     )
 
     assert np.allclose(net_taxes, expected)
+
+
+p = Specifications()
+p.update_specifications({"tau_c": [[0.1]]})
+c = np.ones((p.T, p.I, p.S, p.J)) * 0.3
+p_i = np.ones((p.T, p.I)) * 1.2
+
+
+@pytest.mark.parametrize(
+    "c,p_i,p,method,expected",
+    [
+        (c, p_i, p, "TPI", np.ones((p.T, p.S, p.J)) * 0.036),
+        (
+            c[-1, :, :, :],
+            p_i[-1, :],
+            p,
+            "SS",
+            np.ones((p.T, p.S, p.J)) * 0.036,
+        ),
+    ],
+    ids=[
+        "TPI",
+        "SS",
+    ],
+)
+def test_cons_tax_liab(c, p_i, p, method, expected):
+    c_tax_test = tax.cons_tax_liab(c, p_i, p, method)
+
+    assert np.allclose(c_tax_test, expected)


### PR DESCRIPTION
This PR adds a consumption tax liability function to the `ogcore.tax` module.  This is so that the calculation of consumption taxes is centralized and properly tested.

This PR addresses Issue #1022 and also fixes a bug introduced in PR #1054 that saved arrays of sales tax liability of the wrong dimension to the SS and TPI output.

