### PR TITLE
Fix logging.warning call in SS

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -1083,7 +1083,7 @@ def SS_solver(
         )
 
     if ENFORCE_SOLUTION_CHECKS and (max(np.absolute(RC)) > p.RC_SS):
-        logging.warning("Resource Constraint Difference:", RC)
+        logging.warning(f"Resource Constraint Difference: {RC}")
         err = "Steady state aggregate resource constraint not satisfied"
         raise RuntimeError(err)
 


### PR DESCRIPTION
Use parametrized formatting of logging module to prevent format error.