### PR TITLE
Update uv.lock

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,6 +9,7 @@ on:
       - '**.csv'
       - '**.pkl'
       - '**.pbz2'
+      - '**.lock'
   pull_request:
     paths:
       - '**.yml'
@@ -18,6 +19,7 @@ on:
       - '**.csv'
       - '**.pkl'
       - '**.pbz2'
+      - '**.lock'
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.8] - 2026-04-15 20:30:00
+## [0.15.8] - 2026-04-16 00:30:00
 
 ### Added
 
-- Updated the `uv.lock` file to the current version of `ogcore` package (0.15.8)
+- Updates the `uv.lock` file to the current version of `ogcore` package (0.15.8)
+- Adds `'**.lock'` to the paths in `build_and_test.yml` so that any changes to the `uv.lock` file trigger the GH Action CI tests in `build_and_test.yml`
+- Incorporates the dependabot updates to `uv.lock` versions from [PR 1105](https://github.com/PSLmodels/OG-Core/pull/1105) and [PR 1106](https://github.com/PSLmodels/OG-Core/pull/1106).
 
 ## [0.15.7] - 2026-04-15 20:00:00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.8] - 2026-04-15 20:30:00
+
+### Added
+
+- Updated the `uv.lock` file to the current version of `ogcore` package (0.15.8)
+
 ## [0.15.7] - 2026-04-15 20:00:00
 
 ### Added
@@ -530,6 +536,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.15.8]: https://github.com/PSLmodels/OG-Core/compare/v0.15.7...v0.15.8
 [0.15.7]: https://github.com/PSLmodels/OG-Core/compare/v0.15.6...v0.15.7
 [0.15.6]: https://github.com/PSLmodels/OG-Core/compare/v0.15.5...v0.15.6
 [0.15.5]: https://github.com/PSLmodels/OG-Core/compare/v0.15.4...v0.15.5

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -20,4 +20,4 @@ from ogcore.tax import *  # noqa: F403
 from ogcore.txfunc import *  # noqa: F403
 from ogcore.utils import *  # noqa: F403
 
-__version__ = "0.15.7"
+__version__ = "0.15.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ogcore"
-version = "0.15.7"
+version = "0.15.8"
 authors = [
     {name = "Jason DeBacker and Richard W. Evans"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1771,7 +1771,7 @@ wheels = [
 
 [[package]]
 name = "ogcore"
-version = "0.15.6"
+version = "0.15.8"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
This PR:
- Adds `'**.lock'` to the paths in `build_and_test.yml` so that any changes to the `uv.lock` file trigger the GH Action CI tests in `build_and_test.yml`
    - I noticed that dependabot PRs that only updated the `uv.lock` file would only test the `ruff` linter (see PR #1102, PR #1103, PR #1105, PR #1106). This changes the behavior so that any change to the `uv.lock` file triggers the full set of GH Action CI tests in `build_and_test.yml`.
- Updates the `uv.lock` file to correspond with the current `ogcore` package version of this PR. I noticed that the `uv.lock` file in the previous PRs was using the previous version of `ogcore`. The workflow with any future PRs that change the version should be:
    - Update the `ogcore` package version in `pyproject.toml` and `ogcore/__init__.py` and associated descriptions in the `CHANGELOG.md` file.
    - Run `uv lock` in the terminal. This will create a new version of the `uv.lock` that is derived from the `pyproject.toml` file that has the new version number.
    - Commit the updated files, including the `uv.lock` file.

cc: @jdebacker 