### PR TITLE
Update build_and_test.yml to not run codecov for dependabot PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Test
         run: uv run python -m pytest -m "not local and not benchmark" --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/OG-Core')
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/OG-Core') && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml


### PR DESCRIPTION
This PR is a fix for failing CI tests on PRs from dependabot due to failing CodeCov uploads. See PR #1110. Test fail error on the ubuntu Python 3.13 tests is due to "`Error: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1`". This is because dependabot PRs are not allowed to use the `CODECOV_TOKEN` secret unless the same secret in the "Actions" section of the repository settings is included in the "Dependabot" section. Rather than have dependabot version update PRs run and upload CodeCov, this PR makes `build_and_test.yml` not run CodeCov for dependabot PRs.

cc: @jdebacker 