### PR TITLE
Updated codecov action to v5 in build_and_test.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ jobs:
         run: uv run python -m pytest -m "not local and not benchmark" --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/OG-Core') && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
This PR updates the `codecov-action` in `build_and_test.yml` to v5. This fixes an issue with the ubuntu CI GitHub Actions in which the CodeCov action would give the following error:
```
Error: Codecov: Uploader shasum does not match -- uploader hash: 4a9a4d50df1cb796229e27f8dcc292bf5538779cd906851b37eb361202a43dce  codecov, public hash: 8930c4bb30254a42f3d8c340706b1be340885e20c0df5160a24efa2e030e662b  codecov"
```

cc: @jdebacker 

