### PR TITLE
Plotting fertility rates

### DIFF
--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -214,22 +214,24 @@ def get_fert(
     # Create plots if needed
     if graph:
         if start_year == end_year:
-            years_to_plot = [start_year]
+            years_list = [str(start_year)]
+            fert_rates_list = [fert_rates_2D]
         else:
-            years_to_plot = [start_year, end_year]
+            years_list = [str(x) for x in np.arange(start_year, end_year + 1)]
+            fert_rates_list = [
+                fert_rates_2D[i, :] for i in range(fert_rates_2D.shape[0])
+            ]
         if plot_path is not None:
             pp.plot_fert_rates(
-                [fert_rates_2D],
-                start_year=start_year,
-                years_to_plot=years_to_plot,
+                fert_rates_list,
+                labels=years_list,
                 path=plot_path,
             )
             return fert_rates_2D
         else:
             fig = pp.plot_fert_rates(
-                [fert_rates_2D],
-                start_year=start_year,
-                years_to_plot=years_to_plot,
+                fert_rates_list,
+                labels=years_list,
             )
             return fert_rates_2D, fig
     else:

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -215,7 +215,7 @@ def get_fert(
     if graph:
         if start_year == end_year:
             years_list = [str(start_year)]
-            fert_rates_list = [fert_rates_2D]
+            fert_rates_list = [fert_rates_2D[0, :]]
         else:
             years_list = [str(x) for x in np.arange(start_year, end_year + 1)]
             fert_rates_list = [

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -18,19 +18,19 @@ def plot_imm_rates(
     path=None,
 ):
     """
-    Plot fertility rates from the data
+    Plot immigration rates from the data
 
     Args:
         imm_rates (NumPy array): immigration rates for each of
             totpers
         start_year (int): first year of data
         years_to_plot (list): list of years to plot
-        source (str): data source for fertility rates
+        source (str): data source for immigration rates
         path (str): path to save figure to, if None then figure
             is returned
 
     Returns:
-        fig (Matplotlib plot object): plot of fertility rates
+        fig (Matplotlib plot object): plot of immigration rates
 
     """
     # create line styles to cycle through
@@ -38,7 +38,6 @@ def plot_imm_rates(
     for y in years_to_plot:
         i = start_year - y
         plt.plot(imm_rates[i, :], c="blue", label="Year " + str(y))
-    # plt.title('Fertility rates by age ($f_{s}$)',
     #     fontsize=20)
     plt.xlabel(r"Age $s$")
     plt.ylabel(r"Immigration rate $i_{s}$")
@@ -50,7 +49,7 @@ def plot_imm_rates(
         fontsize=9,
     )
     if include_title:
-        plt.title("Immigration Rates")
+        plt.title("Immigration Rates by Age")
     # Save or return figure
     if path:
         output_path = os.path.join(path, "imm_rates")
@@ -366,8 +365,6 @@ def plot_chi_n(
 def plot_fert_rates(
     fert_rates_list,
     labels=[""],
-    start_year=DEFAULT_START_YEAR,
-    years_to_plot=[DEFAULT_START_YEAR],
     include_title=False,
     source="United Nations, World Population Prospects",
     path=None,
@@ -379,8 +376,6 @@ def plot_fert_rates(
         fert_rates_list (list): list of Numpy arrays of fertility rates
             for each model period and age
         labels (list): list of labels for the legend
-        start_year (int): first year of data
-        years_to_plot (list): list of years to plot
         include_title (bool): whether to include a title in the plot
         source (str): data source for fertility rates
         path (str): path to save figure to, if None then figure
@@ -390,23 +385,40 @@ def plot_fert_rates(
         fig (Matplotlib plot object): plot of fertility rates
 
     """
-    # create line styles to cycle through
     fig, ax = plt.subplots()
-    for y in years_to_plot:
-        i = start_year - y
+    num_series = len(fert_rates_list)
+
+    if num_series > 4:
+        cm = plt.get_cmap("coolwarm")
+        # Attempt to convert labels to numeric values for colormap scaling
+        try:
+            label_values = [int(label) for label in labels]
+        except (ValueError, TypeError):
+            label_values = list(range(num_series))
+
+        vmin, vmax = min(label_values), max(label_values)
+        norm = plt.Normalize(vmin=vmin, vmax=vmax)
         for i, fert_rates in enumerate(fert_rates_list):
-            plt.plot(fert_rates[i, :], label=labels[i] + " " + str(y))
+            ax.plot(fert_rates, color=cm(norm(label_values[i])))
+        sm = plt.cm.ScalarMappable(cmap=cm, norm=norm)
+        sm.set_array([])
+        plt.colorbar(sm, ax=ax, label="Year")
+    else:
+        for i, fert_rates in enumerate(fert_rates_list):
+            ax.plot(fert_rates, label=labels[i])
+        ax.legend(loc="upper right")
+
     if include_title:
-        plt.title("Fertility rates by age ($f_{s}$)", fontsize=20)
-    plt.xlabel(r"Age $s$")
-    plt.ylabel(r"Fertility rate $f_{s}$")
-    plt.legend(loc="upper right")
-    plt.text(
+        ax.set_title("Fertility rates by age ($f_{s}$)", fontsize=20)
+    ax.set_xlabel(r"Age $s$")
+    ax.set_ylabel(r"Fertility rate $f_{s}$")
+    ax.text(
         -5,
         -0.023,
         "Source: " + source,
         fontsize=9,
     )
+
     # Save or return figure
     if path:
         output_path = os.path.join(path, "fert_rates")

--- a/ogcore/parameter_plots.py
+++ b/ogcore/parameter_plots.py
@@ -387,6 +387,9 @@ def plot_fert_rates(
     """
     fig, ax = plt.subplots()
     num_series = len(fert_rates_list)
+    assert num_series == len(labels), (
+        "Number of series must match number of labels"
+    )
 
     if num_series > 4:
         cm = plt.get_cmap("coolwarm")

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -243,6 +243,39 @@ def test_get_fert():
 
 
 @pytest.mark.local
+def test_get_fert_multi_year():
+    """
+    Test get_fert with multiple years (start_year != end_year) and graph=True.
+    Covers the else branch that builds years_list and fert_rates_list for
+    multiple years.
+    """
+    S = 100
+    fert_rates, fig = demographics.get_fert(
+        S, 0, 99, start_year=2023, end_year=2024, graph=True
+    )
+    assert fert_rates.shape == (2, S)
+    assert fig
+
+
+@pytest.mark.local
+def test_get_fert_graph_with_plot_path(tmpdir):
+    """
+    Test get_fert with graph=True and a plot_path.
+    Covers the plot_path is not None branch (saves figure, returns only
+    fert_rates_2D without a fig object).
+    """
+    import os
+    import matplotlib.image as mpimg
+
+    S = 100
+    result = demographics.get_fert(S, 0, 99, graph=True, plot_path=str(tmpdir))
+    # When plot_path is given, only fert_rates_2D is returned (not a tuple)
+    assert result.shape[1] == S
+    img = mpimg.imread(os.path.join(str(tmpdir), "fert_rates.png"))
+    assert isinstance(img, np.ndarray)
+
+
+@pytest.mark.local
 def test_get_mort():
     """
     Test of function to get mortality rates from data

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -281,6 +281,46 @@ def test_plot_fert_rates_save_fig(tmpdir):
     assert isinstance(img, np.ndarray)
 
 
+def test_plot_fert_rates_many_series_numeric_labels():
+    """Test plot_fert_rates with >4 series and numeric (year) labels.
+    Covers the num_series > 4 branch with the try block succeeding."""
+    totpers = base_params.S
+    fert_rates_list = [np.random.uniform(size=totpers) for _ in range(5)]
+    labels = ["2020", "2021", "2022", "2023", "2024"]
+    fig = parameter_plots.plot_fert_rates(
+        fert_rates_list, labels=labels, include_title=True
+    )
+    assert fig
+    plt.close()
+
+
+def test_plot_fert_rates_many_series_nonnumeric_labels():
+    """Test plot_fert_rates with >4 series and non-numeric labels.
+    Covers the num_series > 4 branch with the except block (fallback to range).
+    """
+    totpers = base_params.S
+    fert_rates_list = [np.random.uniform(size=totpers) for _ in range(5)]
+    labels = ["Baseline", "Reform A", "Reform B", "Reform C", "Reform D"]
+    fig = parameter_plots.plot_fert_rates(
+        fert_rates_list, labels=labels, include_title=False
+    )
+    assert fig
+    plt.close()
+
+
+def test_plot_fert_rates_many_series_save_fig(tmpdir):
+    """Test plot_fert_rates with >4 series saves a figure to disk."""
+    totpers = base_params.S
+    fert_rates_list = [np.random.uniform(size=totpers) for _ in range(5)]
+    labels = ["2020", "2021", "2022", "2023", "2024"]
+    parameter_plots.plot_fert_rates(
+        fert_rates_list, labels=labels, path=tmpdir
+    )
+    img = mpimg.imread(os.path.join(tmpdir, "fert_rates.png"))
+
+    assert isinstance(img, np.ndarray)
+
+
 def test_plot_g_n():
     p = Specifications()
     fig = parameter_plots.plot_g_n([p], include_title=True)

--- a/tests/test_parameter_plots.py
+++ b/tests/test_parameter_plots.py
@@ -218,8 +218,6 @@ def test_plot_population_save_fig(tmpdir):
 
 def test_plot_fert_rates():
     totpers = base_params.S
-    min_yr = 20
-    max_yr = 100
     fert_data = (
         np.array(
             [
@@ -250,8 +248,6 @@ def test_plot_fert_rates():
 
 def test_plot_fert_rates_save_fig(tmpdir):
     totpers = base_params.S
-    min_yr = 20
-    max_yr = 100
     fert_data = (
         np.array(
             [


### PR DESCRIPTION
This PR fixes a bug in the `parameter_plots.plot_fert_rates` function which resulted unexpected behavior when trying to plot multiple years of data. The changes here still preserve the flexibility of `parameter_plots.plot_fert_rates` (e.g., you can input any conforming series of fertility rates), but enable one to plot and concisely label multiple years of data. 

As an example.  Using:
```python
demog.get_fert(start_year=2025, end_year=2055, graph=True)
```
returns:
<img width="1754" height="1518" alt="fert_rates" src="https://github.com/user-attachments/assets/4402a80d-5aaf-4377-9114-79d580953661" />
