### PR TITLE
Allow negative consumption taxes

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -1259,7 +1259,7 @@
         ],
         "validators": {
             "range": {
-                "min": 0.0,
+                "min": -5.0,
                 "max": 5.0
             }
         }


### PR DESCRIPTION
This PR changes the minimum value allowable for `tau_c` so that it can reflect subsidies.