### PR TITLE
Fix output plot unit labels

### DIFF
--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -12,6 +12,9 @@ import ogcore.utils as utils
 from ogcore.utils import Inequality
 
 
+INTEREST_RATE_VARS = {"r_gov", "r", "r_p"}
+
+
 def plot_aggregates(
     base_tpi,
     base_params,
@@ -41,7 +44,8 @@ def plot_aggregates(
         var_list (list): names of variable to plot
         plot_type (string): type of plot, can be:
             'pct_diff': plots percentage difference between baseline
-                and reform ((reform-base)/base)
+                and reform ((reform-base)/base). For interest rates,
+                percentage point differences are plotted.
             'diff': plots difference between baseline and reform
                 (reform-base)
             'levels': plot variables in model units
@@ -73,6 +77,8 @@ def plot_aggregates(
     # Check that reform included if doing pct_diff or diff plot
     if plot_type == "pct_diff" or plot_type == "diff":
         assert reform_tpi is not None
+    only_interest_rates = all(v in INTEREST_RATE_VARS for v in var_list)
+    has_interest_rates = any(v in INTEREST_RATE_VARS for v in var_list)
     fig1, ax1 = plt.subplots()
     if not stationarized:
         for v in var_list:
@@ -91,7 +97,12 @@ def plot_aggregates(
                 plot_var = reform_tpi[v] - base_tpi[v]
             else:
                 plot_var = (reform_tpi[v] - base_tpi[v]) / base_tpi[v]
-            ylabel = r"Pct. change"
+            if only_interest_rates:
+                ylabel = r"Percentage point change"
+            elif has_interest_rates:
+                ylabel = r"Pct. or percentage point change"
+            else:
+                ylabel = r"Pct. change"
             plt.plot(
                 year_vec,
                 plot_var[start_index : start_index + num_years_to_plot],
@@ -119,7 +130,7 @@ def plot_aggregates(
                     ],
                     label="Reform " + VAR_LABELS[v],
                 )
-            ylabel = r"Model Units"
+            ylabel = r"Rate" if only_interest_rates else r"Model Units"
         elif plot_type == "forecast":
             # Need reform and baseline to ensure plot makes sense
             assert reform_tpi is not None
@@ -437,8 +448,8 @@ def plot_gdp_ratio(
         p (OG-Core Specifications class): parameters object
         var_list (list): names of variable to plot
         plot_type (string): type of plot, can be:
-            'diff': plots difference between baseline and reform
-                (reform-base)
+            'diff' or 'pct_diff': plots percentage point difference
+                between baseline and reform ratios to GDP (reform-base)
             'levels': plot variables in model units
         num_years_to_plot (integer): number of years to include in plot
         start_year (integer): year to start plot
@@ -453,7 +464,7 @@ def plot_gdp_ratio(
     assert isinstance(start_year, (int, np.integer))
     assert isinstance(num_years_to_plot, int)
     assert num_years_to_plot <= base_params.T
-    if plot_type == "diff":
+    if plot_type != "levels":
         assert reform_tpi is not None
     # Make sure both runs cover same time period
     if reform_tpi:
@@ -510,7 +521,10 @@ def plot_gdp_ratio(
                 plot_var[start_index : start_index + num_years_to_plot],
                 label=ToGDP_LABELS[v],
             )
-    ylabel = r"Percent of GDP"
+    if plot_type == "levels":
+        ylabel = r"Percent of GDP"
+    else:
+        ylabel = r"Percentage points of GDP"
     # vertical markers at certain years
     if vertical_line_years:
         for yr in vertical_line_years:

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -249,6 +249,38 @@ def test_plot_aggregates_not_a_type(tmpdir):
         )
 
 
+def test_plot_aggregates_interest_rate_pct_diff_label():
+    fig = output_plots.plot_aggregates(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        var_list=["r"],
+        plot_type="pct_diff",
+        num_years_to_plot=20,
+        start_year=int(base_params.start_year),
+    )
+
+    assert fig.axes[0].get_ylabel() == "Percentage point change"
+    plt.close()
+
+
+def test_plot_aggregates_interest_rate_levels_label():
+    fig = output_plots.plot_aggregates(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        var_list=["r"],
+        plot_type="levels",
+        num_years_to_plot=20,
+        start_year=int(base_params.start_year),
+    )
+
+    assert fig.axes[0].get_ylabel() == "Rate"
+    plt.close()
+
+
 test_data = [
     (base_tpi, base_params, None, None, None, None, "levels"),
     (base_tpi, base_params, reform_tpi, reform_params, None, None, "levels"),
@@ -314,6 +346,20 @@ def test_plot_gdp_ratio_save_fig(tmpdir):
     img = mpimg.imread(path)
 
     assert isinstance(img, np.ndarray)
+
+
+def test_plot_gdp_ratio_pct_diff_label():
+    fig = output_plots.plot_gdp_ratio(
+        base_tpi,
+        base_params,
+        reform_tpi=reform_tpi,
+        reform_params=reform_params,
+        start_year=int(base_params.start_year),
+        plot_type="pct_diff",
+    )
+
+    assert fig.axes[0].get_ylabel() == "Percentage points of GDP"
+    plt.close()
 
 
 def test_ability_bar():


### PR DESCRIPTION
## Description

Fixes output plot y-axis labels for the unit cases in #1135.

## Related Issues

Closes #1135

## Type of Change

- [ ] Feature (new functionality)
- [ ] Change Request (modification of existing functionality)
- [x] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [x] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

If yes, describe the impact and migration path:


## What was changed?

- Label interest-rate `plot_aggregates(..., plot_type="pct_diff")` outputs as percentage point changes.
- Label interest-rate `plot_aggregates(..., plot_type="levels")` outputs as rates instead of model units.
- Label non-level `plot_gdp_ratio` outputs as percentage points of GDP.
- Added regression assertions for the three label cases.

## How was it tested?

| Test-ID | Status |
|---------|--------|
| T-001 `.venv/bin/python -m pytest tests/test_output_plots.py -q` | passed, 50 tests |
| T-002 `.venv/bin/ruff format --check ogcore/output_plots.py tests/test_output_plots.py` | passed |
| T-003 `.venv/bin/ruff check ogcore/output_plots.py tests/test_output_plots.py` | passed |
| T-004 `git diff --cached --check` | passed |
| T-005 `git diff --cached | gitleaks stdin --no-banner --redact --timeout 30` | passed, no leaks |

Local setup note: `uv sync --extra dev` could not complete on this macOS x86_64 machine because `numba==0.65.1` tried to build `llvmlite==0.47.0` without local LLVM development files. I ran the focused tests in a Python 3.11 editable environment using wheel-compatible `numba==0.61.2`; the changed code paths are limited to Matplotlib label selection and output plot tests.

## Screenshots / Output (if applicable)

N/A

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review
- [x] I have added/updated tests (referencing issue Test-IDs)
- [x] All focused tests pass locally
- [x] I have updated the documentation
- [ ] I have added a changelog entry
- [x] Breaking changes are documented with migration path

## Reviewer Notes

The change is intentionally limited to axis labels and docs for existing plotted values; it does not alter plotted data.