### PR TITLE
Fix consumption plot label escaping

### DIFF
--- a/ogcore/model_variables.json
+++ b/ogcore/model_variables.json
@@ -428,7 +428,7 @@
         "type": "array-like",
         "TPI dimensions": "TxSxJ",
         "SS dimensions": "SxJ",
-        "label": "Household Consumption ($\tilde{c}_{j,s,t}$)",
+        "label": "Household Consumption ($\\tilde{c}_{j,s,t}$)",
         "toGDP_label": ""
     },
     "c_i": {

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -593,3 +593,8 @@ def test_lambda_labels():
     for k, v in labels.items():
         print(k, v)
         assert v == constants.GROUP_LABELS[7][k]
+
+
+def test_consumption_label_uses_latex_tilde():
+    assert "\t" not in constants.VAR_LABELS["c"]
+    assert r"$\tilde{c}_{j,s,t}$" in constants.VAR_LABELS["c"]


### PR DESCRIPTION
## Summary
- escape the LaTeX `\tilde` command in the household composite consumption label so JSON loading does not convert `\t` into a tab
- add a regression test for the consumption plot label

Fixes #1134.

## Testing
- `uv run --extra dev pytest tests/test_output_plots.py::test_consumption_label_uses_latex_tilde -q`
- `uv run --extra dev pytest tests/test_output_plots.py -q`
- `uv run --extra dev ruff check tests/test_output_plots.py`