### PR TITLE
Change aggregate plot default to unstationarized

### DIFF
--- a/ogcore/output_plots.py
+++ b/ogcore/output_plots.py
@@ -19,7 +19,7 @@ def plot_aggregates(
     reform_params=None,
     var_list=["Y", "C", "K", "L"],
     plot_type="pct_diff",
-    stationarized=True,
+    stationarized=False,
     num_years_to_plot=50,
     start_year=DEFAULT_START_YEAR,
     forecast_data=None,
@@ -47,7 +47,7 @@ def plot_aggregates(
             'levels': plot variables in model units
             'forecast': plots variables in levels relative to baseline
                 economic forecast
-        stationarized (bool): whether used stationarized variables
+        stationarized (bool): whether to use stationarized variables
         num_years_to_plot (integer): number of years to include in plot
         start_year (integer): year to start plot
         forecast_data (array_like): baseline economic forecast series,

--- a/tests/test_output_plots.py
+++ b/tests/test_output_plots.py
@@ -2,6 +2,7 @@
 Tests of output_plots.py module
 """
 
+import inspect
 import pytest
 import os
 import sys
@@ -163,6 +164,14 @@ def test_plot_aggregates(
     )
     assert fig
     plt.close()
+
+
+def test_plot_aggregates_defaults_to_unstationarized():
+    stationarized_default = inspect.signature(
+        output_plots.plot_aggregates
+    ).parameters["stationarized"].default
+
+    assert stationarized_default is False
 
 
 test_data = [


### PR DESCRIPTION
## Description
Changes `output_plots.plot_aggregates` so `stationarized` defaults to `False`, matching the expected default in #1133.

## Related Issues
Closes #1133

## Type of Change
- [ ] Feature (new functionality)
- [x] Change Request (modification of existing functionality)
- [ ] Bug Fix
- [ ] Refactoring (no behavior change)
- [ ] Performance improvement
- [ ] Documentation
- [ ] CI / Build

## Breaking Change?
- [ ] Yes
- [x] No

## What was changed?
- Set the public `plot_aggregates(..., stationarized=...)` default to `False`
- Updated the parameter description
- Added a regression test for the default value

## Testing
- `.venv/bin/python -m pytest tests/test_output_plots.py::test_plot_aggregates_defaults_to_unstationarized -q`
- `.venv/bin/python -m pytest tests/test_output_plots.py -q`
- `.venv/bin/ruff check ogcore/output_plots.py tests/test_output_plots.py`
- `git diff --check`