### PR TITLE
Fix Consumption Label

### DIFF
--- a/ogcore/model_variables.json
+++ b/ogcore/model_variables.json
@@ -392,7 +392,7 @@
         "type": "array-like",
         "TPI dimensions": "T",
         "SS dimensions": "scalar",
-        "label": "Composite consumption good price ($\tilde{p}_{t}$)",
+        "label": "Composite consumption good price ($\\tilde{p}_{t}$)",
         "toGDP_label": ""
     },
     "b_sp1": {
@@ -428,7 +428,7 @@
         "type": "array-like",
         "TPI dimensions": "TxSxJ",
         "SS dimensions": "SxJ",
-        "label": "Household Consumption ($\tilde{c}_{j,s,t}$)",
+        "label": "Household Consumption ($\\tilde{c}_{j,s,t}$)",
         "toGDP_label": ""
     },
     "c_i": {

--- a/uv.lock
+++ b/uv.lock
@@ -1734,7 +1734,7 @@ wheels = [
 
 [[package]]
 name = "ogcore"
-version = "0.15.13"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
This PR addresses Issue #1134 by fixing the math notation for the tilde in consumption labels and price labels.