### PR TITLE
Make get_un_data robust to pandas 3.0 and Bearer-prefixed tokens

### DIFF
--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -82,6 +82,11 @@ def get_un_data(
 
     # get data from url
     payload = {}
+    # Accept a token with or without a leading "Bearer " prefix so the
+    # header isn't doubled into "Bearer Bearer <token>".
+    UN_TOKEN = UN_TOKEN.strip()
+    if UN_TOKEN.lower().startswith("bearer "):
+        UN_TOKEN = UN_TOKEN[len("bearer ") :].strip()
     headers = {"Authorization": "Bearer " + UN_TOKEN}
     response = get_legacy_session().get(target, headers=headers, data=payload)
     # Check if the request was successful before processing
@@ -97,7 +102,12 @@ def get_un_data(
             axis=1,
             inplace=True,
         )
-        df.loc[df.age == "100+", "age"] = 100
+        # The "100+" top age bin appears only in some series (mortality,
+        # population), so the age column may parse as int (no "100+") or
+        # str. Normalize to str so the replacement works under pandas
+        # >=3.0's strict string dtype, then cast the column to int.
+        df.age = df.age.astype(str)
+        df.loc[df.age == "100+", "age"] = "100"
         df.age = df.age.astype(int)
         df.year = df.year.astype(int)
         df = df[df.age < 100]  # need to drop 100+ age category


### PR DESCRIPTION
Fixes #1150.

Two robustness fixes to `ogcore.demographics.get_un_data`:

1. **pandas ≥3.0 compatibility.** The `"100+"` top age bin was replaced with the integer `100` in the parsed `age` column, which raises `TypeError` under pandas 3.0's strict string dtype. The dtype also varies by series — fertility (ages 15–49) parses as `int64` with no `"100+"`, while mortality/population parse as `str` and include `"100+"` — so neither a plain int nor a plain string assignment works for both. Fix: normalize the column to `str`, replace `"100+"` → `"100"`, then `astype(int)`. Back-compatible with pandas 2.x; returned data unchanged.

2. **Robust Bearer token.** The auth header was built as `"Bearer " + token`, so a `un_api_token.txt` that already includes a `Bearer ` prefix produced `"Bearer Bearer …"` and silent auth failure (it fell back to the GitHub mirror). An optional leading `Bearer ` is now stripped, so the file may hold either the bare token or the `Bearer …` form the UN portal provides.

Verified on pandas 3.0.3: a live UN pull for Ethiopia (231) succeeds for fertility, mortality, and population (covering both the `int64` and `100+`-string age columns) and authenticates with a `Bearer `-prefixed token (no mirror fallback).
