### PR TITLE
Installer: multi-repo install, catalog expansion, and a machine-readable catalog export

### DIFF
--- a/.github/workflows/check_catalog.yml
+++ b/.github/workflows/check_catalog.yml
@@ -1,0 +1,35 @@
+name: Check installer catalog
+
+on:
+  push:
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - 'scripts/repos.json'
+      - '.github/workflows/check_catalog.yml'
+  pull_request:
+    paths:
+      - 'scripts/install.sh'
+      - 'scripts/install.ps1'
+      - 'scripts/repos.json'
+      - '.github/workflows/check_catalog.yml'
+
+jobs:
+  catalog-in-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Emit catalog from each installer
+        run: |
+          bash scripts/install.sh --list-json > /tmp/catalog_sh.json
+          pwsh -File scripts/install.ps1 -ListJson > /tmp/catalog_ps.json
+      - name: Verify install.sh, install.ps1, and repos.json agree
+        run: |
+          norm() { jq -S '{schema_version, repos: (.repos | sort_by(.key))}' "$1"; }
+          if ! diff <(norm scripts/repos.json) <(norm /tmp/catalog_sh.json); then
+            echo "::error::install.sh --list-json does not match scripts/repos.json"; exit 1
+          fi
+          if ! diff <(norm scripts/repos.json) <(norm /tmp/catalog_ps.json); then
+            echo "::error::install.ps1 -ListJson does not match scripts/repos.json"; exit 1
+          fi
+          echo "Catalog in sync across install.sh, install.ps1, and repos.json."

--- a/scripts/QUICK_INSTALL.md
+++ b/scripts/QUICK_INSTALL.md
@@ -2,7 +2,7 @@
 
 A single installer for OG-Core and its country calibrations. Pre-req: **git** installed. Nothing else.
 
-It installs uv if needed, clones the repo you choose, runs `uv sync --extra dev`, and verifies the import. Pick the repo from a menu, or pass `--repo` / `-Repo`.
+It installs uv if needed, clones the repo(s) you choose, runs `uv sync --extra dev`, and verifies the import. Pick one from a menu, name several with `--repo` / `-Repo`, or install everything with `--all` / `-All`.
 
 You can run it two ways — paste a one-line command, or download the script and run it. Both do the same thing.
 
@@ -44,27 +44,38 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 
 By default the installer shows a menu of repos and prompts for a destination. Flags let you go straight there — they work with either method above:
 
-- `--repo` / `-Repo` — a short key for a repo in the built-in catalog:
+- `--repo` / `-Repo` — a short key for a repo in the built-in catalog. To install several at once: on macOS/Linux repeat the flag (`--repo og-zaf --repo og-idn`), or comma-separate; on Windows comma-separate (`-Repo og-zaf,og-idn`). Keys:
   - `og-core` — base model ([PSLmodels/OG-Core](https://github.com/PSLmodels/OG-Core))
-  - `og-eth` — Ethiopia calibration ([EAPD-DRB/OG-ETH](https://github.com/EAPD-DRB/OG-ETH)); works once its uv migration lands
-- `--repo-url` / `-RepoUrl` — a full git URL, for any other uv-based repo (a fork, or a country repo not yet in the catalog). Clones the default branch.
-- `--branch` / `-Branch` — **for development work**: install a non-default branch (e.g. a fork or a migration branch before it merges).
-- `--dest` / `-Dest` and `--yes` / `-Yes` — set the parent directory and skip the confirmation prompt.
+  - `og-eth` — Ethiopia ([EAPD-DRB/OG-ETH](https://github.com/EAPD-DRB/OG-ETH))
+  - `og-zaf` — South Africa ([EAPD-DRB/OG-ZAF](https://github.com/EAPD-DRB/OG-ZAF))
+  - `og-idn` — Indonesia ([EAPD-DRB/OG-IDN](https://github.com/EAPD-DRB/OG-IDN))
+  - `og-phl` — Philippines ([EAPD-DRB/OG-PHL](https://github.com/EAPD-DRB/OG-PHL))
+- `--all` / `-All` — install every repo in the catalog (each into its own subfolder).
+- `--list` / `-List` and `--list-json` / `-ListJson` — print the repo catalog (human-readable or JSON) and exit, without installing anything. The same catalog is also published as a static file you can fetch directly: [`scripts/repos.json`](repos.json).
+- `--repo-url` / `-RepoUrl` — a full git URL for a single custom repo (a fork, or a country repo not yet in the catalog). Clones the default branch.
+- `--branch` / `-Branch` — **for development work**: install a non-default branch. Single repo only (not valid with `--all` or multiple `--repo`).
+- `--dest` / `-Dest` and `--yes` / `-Yes` — set the parent directory and skip every confirmation prompt. Combine with `--repo` / `--all` for a fully hands-free install.
 
 ```bash
-# macOS / Linux -- OG-Core to ~/Projects/OG-Core, no prompts
+# macOS / Linux
+# one repo, no prompts
 bash install.sh --repo og-core --dest ~/Projects --yes
-# any repo by URL (default branch)
-bash install.sh --repo-url https://github.com/OWNER/OG-XYZ.git
-# a specific branch (development)
+# several at once (repeat the flag, or comma-separate)
+bash install.sh --repo og-zaf --repo og-idn --dest ~/Projects
+# hands-free: install everything, no prompts
+bash install.sh --all --dest ~/Projects --yes
+# a single custom repo on a specific branch (development)
 bash install.sh --repo-url https://github.com/OWNER/OG-XYZ.git --branch my-feature
 ```
 
 ```powershell
-# Windows -- OG-Core to C:\Users\<you>\Projects\OG-Core, no prompts
+# Windows
+# one repo, no prompts
 powershell -ExecutionPolicy Bypass -File .\install.ps1 -Repo og-core -Dest C:\Users\$env:USERNAME\Projects -Yes
-# any repo by URL (default branch)
-powershell -ExecutionPolicy Bypass -File .\install.ps1 -RepoUrl https://github.com/OWNER/OG-XYZ.git
+# several at once
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -Repo og-zaf,og-idn -Dest C:\OG
+# hands-free: install everything, no prompts
+powershell -ExecutionPolicy Bypass -File .\install.ps1 -All -Dest C:\OG -Yes
 ```
 
 More country calibrations get added to the catalog as they migrate to uv.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -441,12 +441,12 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
                 if ((Normalize-RemoteUrl $existingUrl) -eq (Normalize-RemoteUrl $url)) {
                     $destHasRepo = $true
                 } else {
-                    Write-Fail "$name: destination is a git repo for a different remote" $existingUrl
+                    Write-Fail "${name}: destination is a git repo for a different remote" $existingUrl
                     Record-Repo $name "FAIL" "wrong remote at $destAbs"
                     return
                 }
             } else {
-                Write-Fail "$name: destination exists and is not empty" $destAbs
+                Write-Fail "${name}: destination exists and is not empty" $destAbs
                 Record-Repo $name "FAIL" "destination not empty"
                 return
             }
@@ -462,14 +462,14 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
                 Write-Cmd "git -C $destAbs pull --ff-only"
                 & $GitBin -C $destAbs pull --ff-only
                 if ($LASTEXITCODE -eq 0) { Write-Pass "$name updated" }
-                else { Write-Warn2 "$name: git pull failed; using existing state"; $repoState = "WARN" }
-            } else { Write-Skip "$name: using existing clone as-is" }
+                else { Write-Warn2 "${name}: git pull failed; using existing state"; $repoState = "WARN" }
+            } else { Write-Skip "${name}: using existing clone as-is" }
         } else {
             if ($Branch) { Write-Host ("  Will clone {0} (branch: {1}) into {2}." -f $url, $Branch, $destAbs) }
             else { Write-Host ("  Will clone {0} into {1}." -f $url, $destAbs) }
             $doClone = $true
             if ($PerStep) { if (-not (Prompt-YN "Clone now?" 'y')) { $doClone = $false } }
-            if (-not $doClone) { Write-Fail "$name: clone declined"; Record-Repo $name "FAIL" "clone declined"; return }
+            if (-not $doClone) { Write-Fail "${name}: clone declined"; Record-Repo $name "FAIL" "clone declined"; return }
             if ($Branch) {
                 Write-Cmd "git clone --branch $Branch $url $destAbs"
                 & $GitBin clone --branch $Branch $url $destAbs
@@ -477,7 +477,7 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
                 Write-Cmd "git clone $url $destAbs"
                 & $GitBin clone $url $destAbs
             }
-            if ($LASTEXITCODE -ne 0) { Write-Fail "$name: git clone failed"; Record-Repo $name "FAIL" "git clone failed"; return }
+            if ($LASTEXITCODE -ne 0) { Write-Fail "${name}: git clone failed"; Record-Repo $name "FAIL" "git clone failed"; return }
             $branchNow = "?"
             try { $branchNow = (& $GitBin -C $destAbs rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
             Write-Pass "$name cloned" "$destAbs (branch: $branchNow)"
@@ -485,11 +485,11 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
 
         # --- Verify the repo is uv-native ---
         if (-not (Test-Path (Join-Path $destAbs "pyproject.toml"))) {
-            Write-Fail "$name: no pyproject.toml (not a uv-native repo)"
+            Write-Fail "${name}: no pyproject.toml (not a uv-native repo)"
             Record-Repo $name "FAIL" "no pyproject.toml"
             return
         }
-        if (-not (Test-Path (Join-Path $destAbs "uv.lock"))) { Write-Warn2 "$name: no uv.lock; uv sync will create one" }
+        if (-not (Test-Path (Join-Path $destAbs "uv.lock"))) { Write-Warn2 "${name}: no uv.lock; uv sync will create one" }
 
         # --- uv sync ---
         $syncArgs = @("sync")
@@ -499,18 +499,18 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
             Write-Host "  Will run: uv $($syncArgs -join ' ')  (in $destAbs)"
             if (-not (Prompt-YN "Run uv sync now?" 'y')) { $doSync = $false }
         }
-        if (-not $doSync) { Write-Fail "$name: uv sync declined"; Record-Repo $name "FAIL" "uv sync declined"; return }
+        if (-not $doSync) { Write-Fail "${name}: uv sync declined"; Record-Repo $name "FAIL" "uv sync declined"; return }
         Write-Cmd "uv $($syncArgs -join ' ')  (cwd: $destAbs)"
         Push-Location $destAbs
         $syncRc = 1
         try { & $UvBin @syncArgs; $syncRc = $LASTEXITCODE } finally { Pop-Location }
-        if ($syncRc -ne 0) { Write-Fail "$name: uv sync failed"; Record-Repo $name "FAIL" "uv sync failed"; return }
+        if ($syncRc -ne 0) { Write-Fail "${name}: uv sync failed"; Record-Repo $name "FAIL" "uv sync failed"; return }
         Write-Pass "$name installed (uv sync)"
 
         # --- Verify import ---
         $venvPy = Join-Path $destAbs ".venv\Scripts\python.exe"
         if (-not (Test-Path $venvPy)) {
-            Write-Fail "$name: venv python not found" $venvPy
+            Write-Fail "${name}: venv python not found" $venvPy
             Record-Repo $name "FAIL" "no venv python"
             return
         }
@@ -518,15 +518,15 @@ function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
         if ($LASTEXITCODE -eq 0) {
             $ver = "?"
             try { $ver = (& $venvPy -W ignore -c "import $pkg; print(getattr($pkg, '__version__', '?'))" 2>&1 | Select-Object -Last 1).ToString().Trim() } catch {}
-            Write-Pass "$name: import $pkg" $ver
+            Write-Pass "${name}: import $pkg" $ver
             if ($repoState -eq "WARN") { Record-Repo $name "WARN" "import $pkg ($ver); pull warning" }
             else { Record-Repo $name "PASS" "import $pkg ($ver)" }
         } else {
-            Write-Fail "$name: import $pkg failed" "package not importable; check log above"
+            Write-Fail "${name}: import $pkg failed" "package not importable; check log above"
             Record-Repo $name "FAIL" "import $pkg failed"
         }
     } catch {
-        Write-Fail "$name: unexpected error" $_.Exception.Message
+        Write-Fail "${name}: unexpected error" $_.Exception.Message
         Record-Repo $name "FAIL" "error: $($_.Exception.Message)"
     }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,25 +5,36 @@
 .DESCRIPTION
     Takes a user from zero (only git installed) to a working OG-* model env:
       1. Install uv (if not present)
-      2. Clone the chosen repo
+      2. Clone the chosen repo(s)
       3. uv sync --extra dev (installs Python + project + deps)
       4. Verify import
 
+    Installs one repo, several (-Repo og-zaf,og-idn), or all (-All).
     Only repos that have migrated to uv (pyproject.toml + uv.lock) are offered.
 
 .PARAMETER Repo
-    Skip the model menu. One of: og-core, og-eth.
+    Catalog repo key(s) to install. Comma-separate for several:
+    -Repo og-zaf,og-idn  (see -List for valid keys).
+
+.PARAMETER All
+    Install every repo in the catalog.
+
+.PARAMETER List
+    Print the repo catalog (human-readable) and exit.
+
+.PARAMETER ListJson
+    Print the repo catalog as JSON and exit.
 
 .PARAMETER RepoUrl
-    Use a custom Git URL (e.g. your fork or SSH URL). Bypasses the menu.
+    Install one custom Git URL (single repo only). Bypasses the menu.
 
 .PARAMETER Dest
-    Parent directory where the clone is created. Default: current directory.
-    The clone always lands in <Dest>\<RepoName>.
+    Parent directory for the clone(s). Default: current directory.
+    Each repo lands in <Dest>\<RepoName>.
 
 .PARAMETER Branch
-    For development: clone a non-default branch (default: repo's default
-    branch). Useful for testing forks/PRs before they merge.
+    For development: clone a non-default branch. Single repo only (not valid
+    with -All or multiple -Repo).
 
 .PARAMETER Yes
     Auto-confirm every prompt (non-interactive).
@@ -42,16 +53,23 @@
     Fully interactive: pick a model and a destination, then install.
 
 .EXAMPLE
-    .\scripts\install.ps1 -Repo og-eth -Dest C:\work -Yes
-    Unattended install of OG-ETH into C:\work\OG-ETH.
+    .\scripts\install.ps1 -Repo og-zaf,og-idn -Dest C:\OG
+    Install several models at once into C:\OG.
+
+.EXAMPLE
+    .\scripts\install.ps1 -All -Dest C:\OG -Yes
+    Hands-free: install every repo into C:\OG with no prompts.
 #>
 
 [CmdletBinding()]
 param(
-    [string]$Repo = "",
+    [string[]]$Repo = @(),
+    [switch]$All,
     [string]$RepoUrl = "",
     [string]$Branch = "",
     [string]$Dest = "",
+    [switch]$List,
+    [switch]$ListJson,
     [switch]$Yes,
     [switch]$NoDevDeps,
     [switch]$SkipUvInstall,
@@ -70,8 +88,33 @@ $WithDevDeps = -not $NoDevDeps
 # -- Repo catalog (only uv-migrated repos) -------------------------------------
 $Repos = @(
     [pscustomobject]@{ Key="og-core"; Owner="PSLmodels"; Name="OG-Core"; Pkg="ogcore"; Desc="base model (no country calibration)" },
-    [pscustomobject]@{ Key="og-eth";  Owner="EAPD-DRB";  Name="OG-ETH";  Pkg="ogeth";  Desc="Ethiopia" }
+    [pscustomobject]@{ Key="og-eth";  Owner="EAPD-DRB";  Name="OG-ETH";  Pkg="ogeth";  Desc="Ethiopia" },
+    [pscustomobject]@{ Key="og-zaf";  Owner="EAPD-DRB";  Name="OG-ZAF";  Pkg="ogzaf";  Desc="South Africa" },
+    [pscustomobject]@{ Key="og-idn";  Owner="EAPD-DRB";  Name="OG-IDN";  Pkg="ogidn";  Desc="Indonesia" },
+    [pscustomobject]@{ Key="og-phl";  Owner="EAPD-DRB";  Name="OG-PHL";  Pkg="ogphl";  Desc="Philippines" }
 )
+
+# -- Catalog listing (-List / -ListJson) ---------------------------------------
+# Emit from the embedded $Repos (runtime source of truth) so it works even when
+# only the script is fetched. scripts/repos.json holds the same data as a file;
+# a CI check keeps them in sync.
+if ($ListJson) {
+    $catalog = [pscustomobject]@{
+        schema_version = 1
+        repos = @($Repos | ForEach-Object {
+            [pscustomobject]@{ key = $_.Key; owner = $_.Owner; repo = $_.Name; package = $_.Pkg; description = $_.Desc }
+        })
+    }
+    $catalog | ConvertTo-Json -Depth 5
+    exit 0
+}
+if ($List) {
+    "{0,-9}  {1,-22}  {2,-8}  {3}" -f "KEY", "REPO", "PACKAGE", "DESCRIPTION"
+    foreach ($r in $Repos) {
+        "{0,-9}  {1,-22}  {2,-8}  {3}" -f $r.Key, "$($r.Owner)/$($r.Name)", $r.Pkg, $r.Desc
+    }
+    exit 0
+}
 
 # -- Colors --------------------------------------------------------------------
 $UseAnsi = $Host.UI.SupportsVirtualTerminal -or ($env:WT_SESSION -ne $null)
@@ -120,12 +163,21 @@ function Write-Skip($label, $detail = "") {
 }
 function Write-Cmd($cmd) { Write-Host "  $DIM`$ $cmd$RESET" }
 
-$TotalSteps = 4
-function Step-Banner($n, $title) {
+function Write-Section($title) {
     Write-Host ""
     Write-Hr
-    Write-Host "  ${BOLD}Step $n of ${TotalSteps}: $title${RESET}"
+    Write-Host "  ${BOLD}$title${RESET}"
     Write-Hr
+}
+
+function Fail-Arg($msg) {
+    Write-Host "${RED}ERROR:${RESET} $msg" -ForegroundColor Red
+    Stop-TranscriptIfActive
+    exit 2
+}
+
+function Normalize-RemoteUrl($u) {
+    return ($u -replace '\.git/?$', '').ToLower()
 }
 
 function Test-Interactive {
@@ -141,7 +193,8 @@ function Prompt-YN($prompt, $default = 'y') {
     }
     if (-not (Test-Interactive)) {
         Write-Host "${RED}ERROR:${RESET} non-interactive session and -Yes not given." -ForegroundColor Red
-        return $false
+        Stop-TranscriptIfActive
+        exit 2
     }
     while ($true) {
         $ans = Read-Host "$prompt $opts"
@@ -197,12 +250,12 @@ function Detect-Uv {
 [void](Detect-Uv)
 $UvPresent = [bool]$UvBin
 
-# -- Pick repo -----------------------------------------------------------------
+# -- Pick repo interactively (single repo; multi is opt-in via -Repo/-All) -----
 $RepoOwner = $null; $RepoName = $null; $PkgName = $null; $RepoDesc = $null
 
 function Choose-RepoInteractive {
     if (-not (Test-Interactive)) {
-        Write-Host "${RED}ERROR:${RESET} no -Repo given and session is non-interactive." -ForegroundColor Red
+        Write-Host "${RED}ERROR:${RESET} no -Repo/-All given and session is non-interactive." -ForegroundColor Red
         Stop-TranscriptIfActive; exit 2
     }
     Write-Host ""
@@ -210,7 +263,7 @@ function Choose-RepoInteractive {
     Write-Host "  ${BOLD}OG-* Installer (uv-based)${RESET}"
     Write-HrThick
     Write-Host "  Which OG country model do you want to install?"
-    Write-Host "  ${DIM}(only repos that have migrated to uv are listed)${RESET}"
+    Write-Host "  ${DIM}(only repos that have migrated to uv are listed; use -All for every one)${RESET}"
     Write-Host ""
     $i = 1
     foreach ($r in $script:Repos) {
@@ -231,47 +284,63 @@ function Choose-RepoInteractive {
             return
         }
         $r = $script:Repos[$n - 1]
-        $script:Repo = $r.Key
         $script:RepoOwner = $r.Owner; $script:RepoName = $r.Name
         $script:PkgName = $r.Pkg; $script:RepoDesc = $r.Desc
         return
     }
 }
 
-if ($RepoUrl -and -not $Repo) {
-    # custom URL via CLI; menu skipped
-} elseif ($Repo) {
-    $match = $Repos | Where-Object { $_.Key -eq $Repo }
-    if (-not $match) {
-        Write-Host "${RED}ERROR:${RESET} unknown -Repo '$Repo'. Use -? for the list." -ForegroundColor Red
-        Stop-TranscriptIfActive; exit 2
+# -- Resolve the list of repos to install --------------------------------------
+$Targets = @()
+if ($RepoUrl) {
+    if ($All -or $Repo.Count -gt 0) {
+        Fail-Arg "-RepoUrl installs a single repo; it cannot be combined with -All or -Repo."
     }
-    $RepoOwner = $match.Owner; $RepoName = $match.Name
-    $PkgName = $match.Pkg; $RepoDesc = $match.Desc
+    $leaf = Split-Path -Leaf $RepoUrl
+    $cuName = $leaf -replace '\.git$', ''
+    $cuPkg = ($cuName.ToLower() -replace '-', '')
+    $Targets += [pscustomobject]@{ Owner="(custom URL)"; Name=$cuName; Pkg=$cuPkg; Desc="custom repo"; Url=$RepoUrl }
+} elseif ($All) {
+    if ($Repo.Count -gt 0) { Fail-Arg "-All installs every repo; do not also pass -Repo." }
+    foreach ($r in $Repos) {
+        $Targets += [pscustomobject]@{ Owner=$r.Owner; Name=$r.Name; Pkg=$r.Pkg; Desc=$r.Desc; Url="https://github.com/$($r.Owner)/$($r.Name).git" }
+    }
+} elseif ($Repo.Count -gt 0) {
+    $seen = @{}
+    foreach ($key in $Repo) {
+        if ($seen.ContainsKey($key)) { continue }
+        $seen[$key] = $true
+        $match = $Repos | Where-Object { $_.Key -eq $key }
+        if (-not $match) { Fail-Arg "unknown -Repo '$key'. Run -List to see valid keys." }
+        $Targets += [pscustomobject]@{ Owner=$match.Owner; Name=$match.Name; Pkg=$match.Pkg; Desc=$match.Desc; Url="https://github.com/$($match.Owner)/$($match.Name).git" }
+    }
 } else {
     Choose-RepoInteractive
+    if ($RepoUrl) {
+        $leaf = Split-Path -Leaf $RepoUrl
+        $cuName = $leaf -replace '\.git$', ''
+        $cuPkg = ($cuName.ToLower() -replace '-', '')
+        $Targets += [pscustomobject]@{ Owner="(custom URL)"; Name=$cuName; Pkg=$cuPkg; Desc="custom repo"; Url=$RepoUrl }
+    } else {
+        $Targets += [pscustomobject]@{ Owner=$RepoOwner; Name=$RepoName; Pkg=$PkgName; Desc=$RepoDesc; Url="https://github.com/$RepoOwner/$RepoName.git" }
+    }
 }
 
-# Custom URL: derive repo name + package name
-if ($RepoUrl -and -not $RepoName) {
-    $leaf = Split-Path -Leaf $RepoUrl
-    $RepoName = $leaf -replace '\.git$', ''
-    $RepoOwner = "(custom URL)"; $RepoDesc = "custom repo"
-    $PkgName = ($RepoName.ToLower() -replace '-', '')
-    $Repo = $PkgName
+$TotalTargets = $Targets.Count
+if ($Branch -and $TotalTargets -gt 1) {
+    Fail-Arg "-Branch can only be used with a single repo (selected: $TotalTargets)."
 }
-if (-not $RepoUrl) {
-    $RepoUrl = "https://github.com/$RepoOwner/$RepoName.git"
-}
+# One repo keeps the per-step confirmations; multiple run as a batch.
+$PerStep = ($TotalTargets -eq 1)
 
-# -- Pick destination ----------------------------------------------------------
+# -- Pick destination (PARENT directory; each repo lands at PARENT\RepoName) ---
 if (-not $Dest) {
     if (-not (Test-Interactive)) {
         $Dest = "."
     } else {
         Write-Host ""
-        Write-Host ("  Where would you like to install {0}?" -f $RepoName)
-        Write-Host ("  Enter the PARENT directory; {0} will be cloned as a subfolder inside." -f $RepoName)
+        Write-Host "  Where would you like to install?"
+        Write-Host "  Enter the PARENT directory; each repo is cloned into its own subfolder."
         Write-Host ("  Default: current directory ({0})" -f (Get-Location).Path)
         $entered = Read-Host "  Parent directory [.]"
         if ([string]::IsNullOrWhiteSpace($entered)) { $Dest = "." } else { $Dest = $entered }
@@ -284,20 +353,18 @@ if ($Dest.StartsWith("~")) {
     $Dest = Join-Path $env:USERPROFILE $Dest.Substring(1).TrimStart('\','/')
 }
 
-# $Dest is the parent directory. Must exist; resolve to absolute.
 if (-not (Test-Path $Dest)) {
     Write-Host "${RED}ERROR:${RESET} parent directory does not exist: $Dest" -ForegroundColor Red
     Write-Host "Create it first (mkdir $Dest) or pick a different -Dest."
     Stop-TranscriptIfActive; exit 1
 }
 $ParentAbs = (Resolve-Path $Dest).Path
-$DestAbs = Join-Path $ParentAbs $RepoName
 
-# Refuse if PARENT is a dangerous system dir. (User-home is fine -- clone lands
+# Refuse if PARENT is a dangerous system dir. (User-home is fine -- clones land
 # inside it, not overwriting it.)
 $parentNorm = $ParentAbs.TrimEnd('\').ToLower()
 $dangerous = @(
-    $env:WINDIR.ToLower(),
+    "${env:WINDIR}".ToLower(),
     "${env:ProgramFiles}".ToLower(),
     "${env:ProgramFiles(x86)}".ToLower()
 )
@@ -312,12 +379,8 @@ Write-HrThick
 Write-Host "  ${BOLD}OG-* Installer (uv-based)${RESET}"
 Write-HrThick
 Write-Host ("  Platform     : Windows {0}" -f $env:PROCESSOR_ARCHITECTURE)
-Write-Host ("  Model        : {0}" -f $RepoName)
-Write-Host ("  Description  : {0}" -f $RepoDesc)
-Write-Host ("  Source       : {0}" -f $RepoUrl)
+Write-Host ("  Destination  : {0}" -f $ParentAbs)
 if ($Branch) { Write-Host ("  Branch       : {0}" -f $Branch) }
-Write-Host ("  Destination  : {0}" -f $DestAbs)
-Write-Host ("  Package      : {0}" -f $PkgName)
 Write-Host ("  Dev/test deps: {0}" -f $(if ($WithDevDeps) { "yes" } else { "no" }))
 if ($UvPresent) {
     Write-Host ("  uv           : {0} {1}detected{2}" -f $UvBin, $GREEN, $RESET)
@@ -326,39 +389,158 @@ if ($UvPresent) {
 }
 if ($WriteLog) { Write-Host ("  Log file     : {0}" -f $LogFile) }
 Write-Host ""
-Write-Host "  ${BOLD}Plan ($TotalSteps steps):${RESET}"
-if ($UvPresent -or $SkipUvInstall) {
-    Write-Host "    1. Install uv                      ${DIM}skipped${RESET}"
-} else {
-    Write-Host "    1. Install uv                      ${DIM}~5MB, seconds${RESET}"
+Write-Host "  ${BOLD}Repos to install ($TotalTargets):${RESET}"
+foreach ($t in $Targets) {
+    Write-Host "    - $($t.Name)  ${DIM}$($t.Desc)${RESET} -> $ParentAbs\$($t.Name)"
 }
-Write-Host ("    2. Clone {0,-25} ${DIM}depends on network${RESET}" -f $RepoName)
-Write-Host "    3. uv sync (Python + deps)         ${DIM}~30s, ~500MB${RESET}"
-Write-Host "    4. Verify installation             ${DIM}a few seconds${RESET}"
 Write-Host ""
-Write-Host "  You will be asked to confirm before each mutating step."
+Write-Host "  Each repo: clone, uv sync (Python + deps, ~30s/~500MB), verify import."
+if ($PerStep) {
+    Write-Host "  You will be asked to confirm before each mutating step."
+} else {
+    Write-Host "  ${BOLD}$TotalTargets repos${RESET} will be installed after one confirmation below."
+}
 Write-Host ""
 
-if (-not (Prompt-YN "Proceed with installation?" 'y')) {
+$proceedPrompt = if ($TotalTargets -gt 1) { "Proceed with installing $TotalTargets repos?" } else { "Proceed with installation?" }
+if (-not (Prompt-YN $proceedPrompt 'y')) {
     Write-Host "${YELLOW}Aborted by user.${RESET}"
     Stop-TranscriptIfActive; exit 0
 }
 
-# -- Result tracking -----------------------------------------------------------
-$StepResults = New-Object System.Collections.Generic.List[object]
-function Record-Step($name, $state, $detail = "") {
-    $script:StepResults.Add([pscustomobject]@{ Name=$name; State=$state; Detail=$detail })
+# -- Per-repo result tracking --------------------------------------------------
+$RepoResults = New-Object System.Collections.Generic.List[object]
+function Record-Repo($name, $state, $detail = "") {
+    $script:RepoResults.Add([pscustomobject]@{ Name=$name; State=$state; Detail=$detail })
 }
+
+# Install ONE repo: clone (or update) + uv sync + verify. Never throws to the
+# caller; records a per-repo result so the loop can continue on failure. Uses
+# script-scope $ParentAbs, $UvBin, $GitBin, $WithDevDeps, $Branch, $PerStep.
+function Install-OneRepo($owner, $name, $pkg, $desc, $url, $idx, $total) {
+    $destAbs = Join-Path $ParentAbs $name
+    $repoState = "PASS"
+    Write-Host ""
+    Write-Hr
+    if ($total -gt 1) {
+        Write-Host "  ${BOLD}[$idx/$total] $name${RESET}  ${DIM}$owner/$name${RESET}"
+    } else {
+        Write-Host "  ${BOLD}$name${RESET}  ${DIM}$owner/$name${RESET}"
+    }
+    Write-Hr
+
+    try {
+        # --- Clone or update existing ---
+        $destHasRepo = $false
+        if (Test-Path $destAbs) {
+            if (@(Get-ChildItem -Force $destAbs -ErrorAction SilentlyContinue).Count -eq 0) {
+                # empty dir; clone into it
+            } elseif (Test-Path (Join-Path $destAbs ".git")) {
+                $existingUrl = ""
+                try { $existingUrl = (& $GitBin -C $destAbs config --get remote.origin.url 2>$null).Trim() } catch {}
+                if ((Normalize-RemoteUrl $existingUrl) -eq (Normalize-RemoteUrl $url)) {
+                    $destHasRepo = $true
+                } else {
+                    Write-Fail "$name: destination is a git repo for a different remote" $existingUrl
+                    Record-Repo $name "FAIL" "wrong remote at $destAbs"
+                    return
+                }
+            } else {
+                Write-Fail "$name: destination exists and is not empty" $destAbs
+                Record-Repo $name "FAIL" "destination not empty"
+                return
+            }
+        }
+
+        if ($destHasRepo) {
+            $branchNow = "?"
+            try { $branchNow = (& $GitBin -C $destAbs rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+            Write-Host ("  Existing clone found at {0} (branch: {1})." -f $destAbs, $branchNow)
+            $doUpdate = $true
+            if ($PerStep) { if (-not (Prompt-YN "Update existing clone (git pull --ff-only)?" 'y')) { $doUpdate = $false } }
+            if ($doUpdate) {
+                Write-Cmd "git -C $destAbs pull --ff-only"
+                & $GitBin -C $destAbs pull --ff-only
+                if ($LASTEXITCODE -eq 0) { Write-Pass "$name updated" }
+                else { Write-Warn2 "$name: git pull failed; using existing state"; $repoState = "WARN" }
+            } else { Write-Skip "$name: using existing clone as-is" }
+        } else {
+            if ($Branch) { Write-Host ("  Will clone {0} (branch: {1}) into {2}." -f $url, $Branch, $destAbs) }
+            else { Write-Host ("  Will clone {0} into {1}." -f $url, $destAbs) }
+            $doClone = $true
+            if ($PerStep) { if (-not (Prompt-YN "Clone now?" 'y')) { $doClone = $false } }
+            if (-not $doClone) { Write-Fail "$name: clone declined"; Record-Repo $name "FAIL" "clone declined"; return }
+            if ($Branch) {
+                Write-Cmd "git clone --branch $Branch $url $destAbs"
+                & $GitBin clone --branch $Branch $url $destAbs
+            } else {
+                Write-Cmd "git clone $url $destAbs"
+                & $GitBin clone $url $destAbs
+            }
+            if ($LASTEXITCODE -ne 0) { Write-Fail "$name: git clone failed"; Record-Repo $name "FAIL" "git clone failed"; return }
+            $branchNow = "?"
+            try { $branchNow = (& $GitBin -C $destAbs rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+            Write-Pass "$name cloned" "$destAbs (branch: $branchNow)"
+        }
+
+        # --- Verify the repo is uv-native ---
+        if (-not (Test-Path (Join-Path $destAbs "pyproject.toml"))) {
+            Write-Fail "$name: no pyproject.toml (not a uv-native repo)"
+            Record-Repo $name "FAIL" "no pyproject.toml"
+            return
+        }
+        if (-not (Test-Path (Join-Path $destAbs "uv.lock"))) { Write-Warn2 "$name: no uv.lock; uv sync will create one" }
+
+        # --- uv sync ---
+        $syncArgs = @("sync")
+        if ($WithDevDeps) { $syncArgs += @("--extra", "dev") }
+        $doSync = $true
+        if ($PerStep) {
+            Write-Host "  Will run: uv $($syncArgs -join ' ')  (in $destAbs)"
+            if (-not (Prompt-YN "Run uv sync now?" 'y')) { $doSync = $false }
+        }
+        if (-not $doSync) { Write-Fail "$name: uv sync declined"; Record-Repo $name "FAIL" "uv sync declined"; return }
+        Write-Cmd "uv $($syncArgs -join ' ')  (cwd: $destAbs)"
+        Push-Location $destAbs
+        $syncRc = 1
+        try { & $UvBin @syncArgs; $syncRc = $LASTEXITCODE } finally { Pop-Location }
+        if ($syncRc -ne 0) { Write-Fail "$name: uv sync failed"; Record-Repo $name "FAIL" "uv sync failed"; return }
+        Write-Pass "$name installed (uv sync)"
+
+        # --- Verify import ---
+        $venvPy = Join-Path $destAbs ".venv\Scripts\python.exe"
+        if (-not (Test-Path $venvPy)) {
+            Write-Fail "$name: venv python not found" $venvPy
+            Record-Repo $name "FAIL" "no venv python"
+            return
+        }
+        & $venvPy -W ignore -c "import $pkg" 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $ver = "?"
+            try { $ver = (& $venvPy -W ignore -c "import $pkg; print(getattr($pkg, '__version__', '?'))" 2>&1 | Select-Object -Last 1).ToString().Trim() } catch {}
+            Write-Pass "$name: import $pkg" $ver
+            if ($repoState -eq "WARN") { Record-Repo $name "WARN" "import $pkg ($ver); pull warning" }
+            else { Record-Repo $name "PASS" "import $pkg ($ver)" }
+        } else {
+            Write-Fail "$name: import $pkg failed" "package not importable; check log above"
+            Record-Repo $name "FAIL" "import $pkg failed"
+        }
+    } catch {
+        Write-Fail "$name: unexpected error" $_.Exception.Message
+        Record-Repo $name "FAIL" "error: $($_.Exception.Message)"
+    }
+}
+
 $StartTime = Get-Date
 
-# -- Step 1: Install uv --------------------------------------------------------
-Step-Banner 1 "Install uv"
+# -- Install uv (once, shared by all repos) ------------------------------------
+Write-Section "Install uv"
+$UvState = "PASS"; $UvDetail = ""
 if ($UvPresent) {
     Write-Pass "uv already present" $UvBin
-    Record-Step "uv" "SKIP" "already present"
+    $UvState = "SKIP"; $UvDetail = "already present"
 } elseif ($SkipUvInstall) {
     Write-Fail "-SkipUvInstall given but no uv found"
-    Record-Step "uv" "FAIL" "no uv and -SkipUvInstall"
     Stop-TranscriptIfActive; exit 1
 } else {
     Write-Host "  Will install uv via the official installer:"
@@ -366,7 +548,6 @@ if ($UvPresent) {
     Write-Host "    Method : irm | iex -- installs to your user profile, no admin."
     Write-Host ""
     if (-not (Prompt-YN "Download and install uv?" 'y')) {
-        Record-Step "uv" "SKIP" "declined"
         Write-Host "${RED}Cannot continue without uv. Aborting.${RESET}"
         Stop-TranscriptIfActive; exit 1
     }
@@ -378,160 +559,28 @@ if ($UvPresent) {
         "[Net.ServicePointManager]::SecurityProtocol = 'Tls12'; iwr https://astral.sh/uv/install.ps1 -UseBasicParsing | iex"
     if ($LASTEXITCODE -ne 0) {
         Write-Fail "uv install subprocess returned $LASTEXITCODE"
-        Record-Step "uv" "FAIL" "install subprocess failed"
         Stop-TranscriptIfActive; exit 1
     }
     [void](Detect-Uv)
     if (-not $UvBin) {
-        # Documented default install location
         $candidate = "$env:USERPROFILE\.local\bin\uv.exe"
         if (Test-Path $candidate) { $UvBin = $candidate }
     }
     if (-not $UvBin -or -not (Test-Path $UvBin)) {
         Write-Fail "uv install completed but binary not found"
-        Record-Step "uv" "FAIL" "binary not found post-install"
         Stop-TranscriptIfActive; exit 1
     }
     $uvVer = ""
     try { $uvVer = ((& $UvBin --version 2>$null) | Select-Object -First 1).Trim() } catch {}
     Write-Pass "uv installed" "$UvBin ($uvVer)"
-    Record-Step "uv" "PASS" $UvBin
+    $UvDetail = $UvBin
 }
 
-# -- Step 2: Clone the repo ----------------------------------------------------
-Step-Banner 2 "Clone $RepoName"
-
-function Normalize-RemoteUrl($u) {
-    return ($u -replace '\.git/?$', '').ToLower()
-}
-
-$DestHasRepo = $false; $DestEmpty = $false
-if (Test-Path $DestAbs) {
-    if ((Get-ChildItem -Force $DestAbs -ErrorAction SilentlyContinue | Measure-Object).Count -eq 0) {
-        $DestEmpty = $true
-    } elseif (Test-Path (Join-Path $DestAbs ".git")) {
-        $existingUrl = ""
-        try { $existingUrl = (& $GitBin -C $DestAbs config --get remote.origin.url 2>$null).Trim() } catch {}
-        if ((Normalize-RemoteUrl $existingUrl) -eq (Normalize-RemoteUrl $RepoUrl)) {
-            $DestHasRepo = $true
-        } else {
-            Write-Fail "Destination is a git repo for a different remote" $existingUrl
-            Write-Host "  Either remove $DestAbs or pick a different destination with -Dest."
-            Record-Step "Clone" "FAIL" "wrong remote"
-            Stop-TranscriptIfActive; exit 1
-        }
-    } else {
-        Write-Fail "Destination exists and is not empty (and not a git clone)" $DestAbs
-        Write-Host "  Either remove $DestAbs or pick a different destination with -Dest."
-        Record-Step "Clone" "FAIL" "destination not empty"
-        Stop-TranscriptIfActive; exit 1
-    }
-}
-
-if ($DestHasRepo) {
-    $branch = "?"
-    try { $branch = (& $GitBin -C $DestAbs rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
-    Write-Host ("  Existing clone of {0} found at {1} (branch: {2})." -f $RepoName, $DestAbs, $branch)
-    Write-Host "  Will run 'git pull --ff-only' to bring it up to date."
-    Write-Host ""
-    if (Prompt-YN "Update existing clone?" 'y') {
-        Write-Cmd "git -C $DestAbs pull --ff-only"
-        & $GitBin -C $DestAbs pull --ff-only
-        if ($LASTEXITCODE -eq 0) {
-            Write-Pass "Repo updated" $DestAbs
-            Record-Step "Clone" "PASS" "updated ($branch)"
-        } else {
-            Write-Warn2 "git pull failed; continuing with existing state"
-            Record-Step "Clone" "WARN" "pull failed; existing state used"
-        }
-    } else {
-        Write-Skip "Update" "using existing clone as-is"
-        Record-Step "Clone" "SKIP" "existing clone used as-is ($branch)"
-    }
-} else {
-    if ($Branch) {
-        Write-Host ("  Will clone {0} (branch: {1}) into {2}." -f $RepoUrl, $Branch, $DestAbs)
-    } else {
-        Write-Host ("  Will clone {0} into {1}." -f $RepoUrl, $DestAbs)
-    }
-    Write-Host ""
-    if (Prompt-YN "Clone now?" 'y') {
-        if ($Branch) {
-            Write-Cmd "git clone --branch $Branch $RepoUrl $DestAbs"
-            & $GitBin clone --branch $Branch $RepoUrl $DestAbs
-        } else {
-            Write-Cmd "git clone $RepoUrl $DestAbs"
-            & $GitBin clone $RepoUrl $DestAbs
-        }
-        if ($LASTEXITCODE -ne 0) { throw "git clone failed (exit $LASTEXITCODE)" }
-        $branch = "?"
-        try { $branch = (& $GitBin -C $DestAbs rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
-        Write-Pass "Cloned" "$DestAbs (branch: $branch)"
-        Record-Step "Clone" "PASS" $branch
-    } else {
-        Write-Fail "Clone declined; cannot continue."
-        Record-Step "Clone" "FAIL" "declined"
-        Stop-TranscriptIfActive; exit 1
-    }
-}
-
-# Verify the repo is uv-native.
-if (-not (Test-Path (Join-Path $DestAbs "pyproject.toml"))) {
-    Write-Fail "$DestAbs has no pyproject.toml"
-    Write-Host "  This installer requires repos that have migrated to uv."
-    Record-Step "Clone" "FAIL" "no pyproject.toml"
-    Stop-TranscriptIfActive; exit 1
-}
-if (-not (Test-Path (Join-Path $DestAbs "uv.lock"))) {
-    Write-Warn2 "$DestAbs has no uv.lock; uv sync will create one"
-}
-
-# -- Step 3: uv sync -----------------------------------------------------------
-Step-Banner 3 "Install $RepoName (uv sync)"
-$syncArgs = @("sync")
-if ($WithDevDeps) { $syncArgs += @("--extra", "dev") }
-Write-Host ("  Will install {0} + Python + all deps into {1}\.venv" -f $RepoName, $DestAbs)
-Write-Host "  Working directory : $DestAbs"
-Write-Host ("  Command           : uv {0}" -f ($syncArgs -join ' '))
-Write-Host ""
-if (Prompt-YN "Run uv sync now?" 'y') {
-    Push-Location $DestAbs
-    try {
-        Write-Cmd ("uv {0}" -f ($syncArgs -join ' '))
-        & $UvBin @syncArgs
-        if ($LASTEXITCODE -ne 0) { throw "uv sync failed (exit $LASTEXITCODE)" }
-        Write-Pass "$RepoName installed (editable)"
-        Record-Step "$RepoName install" "PASS" "uv sync"
-    } finally { Pop-Location }
-} else {
-    Write-Fail "uv sync declined; package will not be importable."
-    Record-Step "$RepoName install" "FAIL" "declined"
-}
-
-# -- Step 4: Verify ------------------------------------------------------------
-Step-Banner 4 "Verify installation"
-$VenvPython = Join-Path $DestAbs ".venv\Scripts\python.exe"
-if (-not (Test-Path $VenvPython)) {
-    Write-Fail "Venv python not found; skipping import check." $VenvPython
-    Record-Step "Verification" "FAIL" "no venv python"
-} else {
-    $pyver = ""
-    try { $pyver = (& $VenvPython -W ignore -c "import sys; print(sys.version.split()[0])" 2>&1 | Select-Object -Last 1).ToString().Trim() } catch {}
-    Write-Pass "Python in .venv" $pyver
-
-    # Run import as a discrete process; merge stderr into stdout so PS doesn't
-    # treat upstream deprecation warnings (e.g. from pygam) as halting errors.
-    # -W ignore silences Python's own warnings.
-    & $VenvPython -W ignore -c "import $PkgName" 2>&1 | Out-Null
-    if ($LASTEXITCODE -eq 0) {
-        $ver = ""
-        try { $ver = (& $VenvPython -W ignore -c "import $PkgName; print(getattr($PkgName, '__version__', '?'))" 2>&1 | Select-Object -Last 1).ToString().Trim() } catch {}
-        Write-Pass "import $PkgName" $ver
-        Record-Step "Verification" "PASS" "import $PkgName ($ver)"
-    } else {
-        Write-Fail "import $PkgName" "package not importable; check log above"
-        Record-Step "Verification" "FAIL" "import $PkgName failed"
-    }
+# -- Install each repo (continue on failure) -----------------------------------
+$idx = 0
+foreach ($t in $Targets) {
+    $idx++
+    Install-OneRepo $t.Owner $t.Name $t.Pkg $t.Desc $t.Url $idx $TotalTargets
 }
 
 # -- Summary -------------------------------------------------------------------
@@ -541,44 +590,40 @@ $ElapsedSec = [int]($Elapsed.TotalSeconds - ($ElapsedMin * 60))
 
 Write-Host ""
 Write-HrThick
-Write-Host ("  ${BOLD}Installation Summary -- {0}${RESET}" -f $RepoName)
+Write-Host "  ${BOLD}Installation Summary${RESET}"
 Write-HrThick
-
+switch ($UvState) {
+    "PASS" { Write-Pass "uv" $UvDetail }
+    "SKIP" { Write-Skip "uv" $UvDetail }
+    default { Write-Warn2 "uv" $UvDetail }
+}
 $AllOk = $true
-foreach ($r in $StepResults) {
+foreach ($r in $RepoResults) {
     switch ($r.State) {
         "PASS" { Write-Pass  $r.Name $r.Detail }
-        "SKIP" { Write-Skip  $r.Name $r.Detail }
         "WARN" { Write-Warn2 $r.Name $r.Detail }
+        "SKIP" { Write-Skip  $r.Name $r.Detail }
         "FAIL" { Write-Fail  $r.Name $r.Detail; $AllOk = $false }
-        default { Write-Warn2 $r.Name "unknown: $($r.State)" }
+        default { Write-Warn2 $r.Name "unknown: $($r.State)"; $AllOk = $false }
     }
 }
 Write-Host ""
 Write-Host ("  Elapsed  : {0}m {1}s" -f $ElapsedMin, $ElapsedSec)
-Write-Host ("  Location : {0}" -f $DestAbs)
-Write-Host ("  Venv     : {0}\.venv" -f $DestAbs)
+Write-Host ("  Location : {0}" -f $ParentAbs)
 if ($WriteLog) { Write-Host ("  Log      : {0}" -f $LogFile) }
 Write-Host ""
 
 if ($AllOk) {
-    Write-Host "  ${GREEN}${BOLD}All steps completed successfully.${RESET}"
+    Write-Host "  ${GREEN}${BOLD}All repos installed successfully.${RESET}"
     Write-Host ""
-    Write-Host "  ${BOLD}To start using ${RepoName}:${RESET}"
-    Write-Host "    cd $DestAbs"
-    Write-Host "    .\.venv\Scripts\Activate.ps1     # activate venv"
-    Write-Host ("    python -W ignore -c `"import {0}; print({0}.__file__)`"" -f $PkgName)
-    Write-Host "  Or run commands without activating:"
-    Write-Host ("    uv run python -W ignore -c `"import {0}; print({0}.__file__)`"" -f $PkgName)
-    $exDir = Join-Path $DestAbs "examples"
-    if (Test-Path $exDir) {
-        Write-Host ""
-        Write-Host ("  Example scripts: {0}" -f $exDir)
+    Write-Host "  ${BOLD}To start using them:${RESET}"
+    foreach ($r in $RepoResults) {
+        Write-Host ("    cd {0}\{1}; .\.venv\Scripts\Activate.ps1" -f $ParentAbs, $r.Name)
     }
     Stop-TranscriptIfActive
     exit 0
 } else {
-    Write-Host "  ${RED}${BOLD}One or more steps failed.${RESET}"
+    Write-Host "  ${RED}${BOLD}One or more repos failed.${RESET}"
     Write-Host ""
     Write-Host "  Review the [FAIL] entries above."
     if ($WriteLog) { Write-Host "  Full output is in: $LogFile" }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,15 +4,17 @@
 #
 # Takes a user from zero (only git installed) to a working OG-* model env:
 #   1. Install uv (if not present)
-#   2. Clone the chosen repo
+#   2. Clone the chosen repo(s)
 #   3. uv sync --extra dev (installs Python + project + deps)
 #   4. Verify import
 #
+# Installs one repo, several (--repo a,b or repeated --repo), or all (--all).
 # Only repos that have migrated to uv (pyproject.toml + uv.lock) are offered.
 #
 # Usage:
-#   ./scripts/install.sh                   # interactive
-#   ./scripts/install.sh --repo og-eth     # skip the model menu
+#   ./scripts/install.sh                            # interactive (one repo)
+#   ./scripts/install.sh --repo og-eth              # skip the model menu
+#   ./scripts/install.sh --all --dest ~/OG --yes    # install everything, no prompts
 #   ./scripts/install.sh --help
 # ──────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -26,10 +28,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPOS=(
     "og-core|PSLmodels|OG-Core|ogcore|base model (no country calibration)"
     "og-eth|EAPD-DRB|OG-ETH|ogeth|Ethiopia"
+    "og-zaf|EAPD-DRB|OG-ZAF|ogzaf|South Africa"
+    "og-idn|EAPD-DRB|OG-IDN|ogidn|Indonesia"
+    "og-phl|EAPD-DRB|OG-PHL|ogphl|Philippines"
 )
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
-REPO_KEY=""
+SELECTED_KEYS=()
+INSTALL_ALL=0
 REPO_URL=""
 BRANCH=""
 DEST=""
@@ -37,6 +43,8 @@ ASSUME_YES=0
 SKIP_UV_INSTALL=0
 WITH_DEV_DEPS=1
 WRITE_LOG=1
+# Scratch fields populated by lookup_repo / choose_repo_interactive.
+REPO_OWNER=""; REPO_NAME=""; PKG_NAME=""; REPO_DESC=""
 
 usage() {
     cat <<EOF
@@ -47,39 +55,93 @@ Usage:
 
 Options:
   -h, --help              Show this message and exit.
+      --list              Print the repo catalog (human-readable) and exit.
+      --list-json         Print the repo catalog as JSON and exit.
   -y, --yes               Auto-confirm every prompt (non-interactive).
-      --repo KEY          Skip menu; one of: og-core, og-eth
-      --repo-url URL      Use a custom Git URL. Bypasses the menu.
-      --branch BRANCH     For development: clone a non-default branch (default:
-                          repo's default branch). Useful for testing forks/PRs.
-      --dest DIR          Parent directory where the clone is created
-                          (default: current directory). The clone always
-                          lands in <DIR>/\${REPO_NAME}.
+      --repo KEY          Install a catalog repo (see --list). Repeat for
+                          several (--repo og-zaf --repo og-idn); a comma-
+                          separated list (--repo og-zaf,og-idn) also works.
+      --all               Install every repo in the catalog.
+      --repo-url URL      Install one custom Git URL (single repo only).
+      --branch BRANCH     For development: clone a non-default branch. Single
+                          repo only (not valid with --all or multiple --repo).
+      --dest DIR          Parent directory for the clone(s) (default: current
+                          directory). Each repo lands in <DIR>/<REPO_NAME>.
       --no-dev-deps       Install runtime deps only (skip dev/test tooling).
       --skip-uv-install   Don't install uv; assume it's already on PATH.
       --no-log            Don't write a log file.
 
 Examples:
-  $0                                        # fully interactive
-  $0 --repo og-eth                          # menu skipped; prompt for dest
-  $0 --repo og-eth --dest ~/Projects --yes        # clones to ~/Projects/OG-ETH
-  $0 --repo-url git@github.com:me/OG-USA.git --dest .
+  $0                                          # interactive (one repo)
+  $0 --repo og-eth                            # menu skipped; prompt for dest
+  $0 --repo og-zaf --repo og-idn --dest ~/OG  # install several
+  $0 --all --dest ~/OG --yes                  # hands-free: install all, no prompts
+  $0 --repo og-eth --dest ~/OG --yes          # hands-free: one repo, no prompts
   $0 --repo-url https://github.com/me/OG-ETH.git --branch my-branch --dest /tmp
 EOF
 }
 
+# ── Catalog listing (--list / --list-json) ────────────────────────────────────
+# Both emit from the embedded REPOS array (the runtime source of truth) so they
+# work even when only the script is fetched (the curl one-liner). scripts/repos.json
+# is the same data as a standalone file; a CI check keeps the two in sync.
+print_catalog_human() {
+    printf '%-9s  %-22s  %-8s  %s\n' "KEY" "REPO" "PACKAGE" "DESCRIPTION"
+    local entry k owner name pkg desc
+    for entry in "${REPOS[@]}"; do
+        IFS='|' read -r k owner name pkg desc <<< "$entry"
+        printf '%-9s  %-22s  %-8s  %s\n' "$k" "$owner/$name" "$pkg" "$desc"
+    done
+}
+
+print_catalog_json() {
+    printf '{\n  "schema_version": 1,\n  "repos": [\n'
+    local entry k owner name pkg desc first=1
+    for entry in "${REPOS[@]}"; do
+        IFS='|' read -r k owner name pkg desc <<< "$entry"
+        if [ "$first" -eq 0 ]; then printf ',\n'; fi
+        first=0
+        printf '    {"key": "%s", "owner": "%s", "repo": "%s", "package": "%s", "description": "%s"}' \
+            "$k" "$owner" "$name" "$pkg" "$desc"
+    done
+    printf '\n  ]\n}\n'
+}
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
+# Split a comma-separated value and append each key to SELECTED_KEYS.
+add_repo_keys() {
+    local value="$1" part
+    local IFS=','
+    for part in $value; do
+        [ -n "$part" ] && SELECTED_KEYS+=("$part")
+    done
+}
+
+# Ensure a value-taking option actually has its value (avoids a raw "$2:
+# unbound variable" crash under set -u when a flag is the last argument).
+need_arg() {
+    if [ "$1" -lt 2 ]; then
+        echo "Option $2 requires a value." >&2
+        echo >&2
+        usage >&2
+        exit 2
+    fi
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         -h|--help) usage; exit 0;;
+        --list) print_catalog_human; exit 0;;
+        --list-json) print_catalog_json; exit 0;;
         -y|--yes) ASSUME_YES=1; shift;;
-        --repo) REPO_KEY="$2"; shift 2;;
-        --repo=*) REPO_KEY="${1#*=}"; shift;;
-        --repo-url) REPO_URL="$2"; shift 2;;
+        --all) INSTALL_ALL=1; shift;;
+        --repo) need_arg $# "--repo"; add_repo_keys "$2"; shift 2;;
+        --repo=*) add_repo_keys "${1#*=}"; shift;;
+        --repo-url) need_arg $# "--repo-url"; REPO_URL="$2"; shift 2;;
         --repo-url=*) REPO_URL="${1#*=}"; shift;;
-        --branch) BRANCH="$2"; shift 2;;
+        --branch) need_arg $# "--branch"; BRANCH="$2"; shift 2;;
         --branch=*) BRANCH="${1#*=}"; shift;;
-        --dest) DEST="$2"; shift 2;;
+        --dest) need_arg $# "--dest"; DEST="$2"; shift 2;;
         --dest=*) DEST="${1#*=}"; shift;;
         --no-dev-deps) WITH_DEV_DEPS=0; shift;;
         --skip-uv-install) SKIP_UV_INSTALL=1; shift;;
@@ -118,13 +180,12 @@ print_warn() { printf "  ${YELLOW}[WARN]${RESET} %s%s\n" "$1" "${2:+  ${DIM}($2)
 print_skip() { printf "  ${YELLOW}[SKIP]${RESET} %s%s\n" "$1" "${2:+  ${DIM}($2)${RESET}}"; }
 echo_cmd()   { printf "  ${DIM}$ %s${RESET}\n" "$*"; }
 
-TOTAL_STEPS=4
-step_banner() {
-    echo
-    hr
-    printf "  ${BOLD}Step %s of %s: %s${RESET}\n" "$1" "$TOTAL_STEPS" "$2"
-    hr
-}
+section() { echo; hr; printf "  ${BOLD}%s${RESET}\n" "$1"; hr; }
+
+err() { printf "${RED}ERROR:${RESET} %s\n" "$1" >&2; exit 2; }
+
+# Normalize a Git URL for comparison (strip trailing .git, lowercase).
+norm_url() { printf '%s' "$1" | sed -E 's#\.git/?$##' | tr '[:upper:]' '[:lower:]'; }
 
 prompt_yn() {
     local prompt="$1" default="${2:-y}" opts
@@ -135,7 +196,7 @@ prompt_yn() {
     fi
     if [ ! -t 0 ]; then
         printf "${RED}ERROR:${RESET} stdin is not a terminal and --yes was not given.\n" >&2
-        return 2
+        exit 2
     fi
     while true; do
         printf "%s %s " "$prompt" "$opts"
@@ -215,10 +276,10 @@ lookup_repo() {
     return 1
 }
 
-# ── Pick repo (interactive menu or from --repo flag) ──────────────────────────
+# ── Pick repo interactively (single repo; multi is opt-in via --repo/--all) ────
 choose_repo_interactive() {
     if [ ! -t 0 ]; then
-        printf "${RED}ERROR:${RESET} no --repo given and stdin is not a terminal.\n" >&2
+        printf "${RED}ERROR:${RESET} no --repo/--all given and stdin is not a terminal.\n" >&2
         exit 2
     fi
     echo
@@ -226,7 +287,7 @@ choose_repo_interactive() {
     printf "  ${BOLD}OG-* Installer (uv-based)${RESET}\n"
     hr_thick
     printf "  Which OG country model do you want to install?\n"
-    printf "  ${DIM}(only repos that have migrated to uv are listed)${RESET}\n"
+    printf "  ${DIM}(only repos that have migrated to uv are listed; use --all for every one)${RESET}\n"
     echo
     local i=1 entry k owner name pkg desc
     for entry in "${REPOS[@]}"; do
@@ -254,43 +315,214 @@ choose_repo_interactive() {
             REPO_URL="$url"; return 0
         fi
         local idx=$((choice - 1))
-        IFS='|' read -r REPO_KEY REPO_OWNER REPO_NAME PKG_NAME REPO_DESC <<< "${REPOS[$idx]}"
+        IFS='|' read -r _ REPO_OWNER REPO_NAME PKG_NAME REPO_DESC <<< "${REPOS[$idx]}"
         return 0
     done
 }
 
-if [ -n "$REPO_URL" ] && [ -z "$REPO_KEY" ]; then
-    : # custom URL; menu skipped
-elif [ -n "$REPO_KEY" ]; then
-    if ! lookup_repo "$REPO_KEY"; then
-        printf "${RED}ERROR:${RESET} unknown --repo '%s'. Use --help for the list.\n" "$REPO_KEY" >&2
-        exit 2
+# ── Per-repo result tracking ──────────────────────────────────────────────────
+REPO_RESULT_NAMES=(); REPO_RESULT_STATES=(); REPO_RESULT_DETAILS=()
+record_repo() { REPO_RESULT_NAMES+=("$1"); REPO_RESULT_STATES+=("$2"); REPO_RESULT_DETAILS+=("$3"); }
+
+# install_one_repo OWNER NAME PKG DESC URL IDX TOTAL
+# Clone (or update) + uv sync + verify for ONE repo. Never exits; records a
+# per-repo result and returns 0 (ok/warn) or 1 (failed) so the caller can
+# continue to the next repo. Uses globals: PARENT_ABS, UV_BIN, GIT_BIN,
+# WITH_DEV_DEPS, BRANCH (single-repo only), PER_STEP (1 = ask before each step).
+install_one_repo() {
+    local owner="$1" name="$2" pkg="$3" desc="$4" url="$5" idx="$6" total="$7"
+    local dest_abs="${PARENT_ABS}/${name}"
+    local repo_state="PASS" branch_now=""
+
+    echo
+    hr
+    if [ "$total" -gt 1 ]; then
+        printf "  ${BOLD}[%d/%d] %s${RESET}  ${DIM}%s${RESET}\n" "$idx" "$total" "$name" "$owner/$name"
+    else
+        printf "  ${BOLD}%s${RESET}  ${DIM}%s${RESET}\n" "$name" "$owner/$name"
     fi
+    hr
+
+    # --- Clone or update existing ---
+    local dest_has_repo=0
+    if [ -d "$dest_abs" ]; then
+        if [ -z "$(ls -A "$dest_abs" 2>/dev/null || true)" ]; then
+            : # empty dir; clone into it
+        elif [ -d "$dest_abs/.git" ]; then
+            local existing_url
+            existing_url="$("$GIT_BIN" -C "$dest_abs" config --get remote.origin.url 2>/dev/null || true)"
+            if [ "$(norm_url "$existing_url")" = "$(norm_url "$url")" ]; then
+                dest_has_repo=1
+            else
+                print_fail "$name: destination is a git repo for a different remote" "$existing_url"
+                record_repo "$name" FAIL "wrong remote at $dest_abs"
+                return 1
+            fi
+        else
+            print_fail "$name: destination exists and is not empty" "$dest_abs"
+            record_repo "$name" FAIL "destination not empty"
+            return 1
+        fi
+    fi
+
+    if [ "$dest_has_repo" = 1 ]; then
+        branch_now="$("$GIT_BIN" -C "$dest_abs" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")"
+        printf "  Existing clone found at %s (branch: %s).\n" "$dest_abs" "$branch_now"
+        local do_update=1
+        if [ "$PER_STEP" = 1 ]; then
+            prompt_yn "Update existing clone (git pull --ff-only)?" y || do_update=0
+        fi
+        if [ "$do_update" = 1 ]; then
+            echo_cmd "git -C $dest_abs pull --ff-only"
+            if "$GIT_BIN" -C "$dest_abs" pull --ff-only; then
+                print_pass "$name updated"
+            else
+                print_warn "$name: git pull failed; using existing state"
+                repo_state="WARN"
+            fi
+        else
+            print_skip "$name: using existing clone as-is"
+        fi
+    else
+        if [ -n "$BRANCH" ]; then
+            printf "  Will clone %s (branch: %s) into %s.\n" "$url" "$BRANCH" "$dest_abs"
+        else
+            printf "  Will clone %s into %s.\n" "$url" "$dest_abs"
+        fi
+        local do_clone=1
+        if [ "$PER_STEP" = 1 ]; then
+            prompt_yn "Clone now?" y || do_clone=0
+        fi
+        if [ "$do_clone" = 0 ]; then
+            print_fail "$name: clone declined"
+            record_repo "$name" FAIL "clone declined"
+            return 1
+        fi
+        if [ -n "$BRANCH" ]; then
+            echo_cmd "git clone --branch $BRANCH $url $dest_abs"
+            if ! "$GIT_BIN" clone --branch "$BRANCH" "$url" "$dest_abs"; then
+                print_fail "$name: git clone failed"; record_repo "$name" FAIL "git clone failed"; return 1
+            fi
+        else
+            echo_cmd "git clone $url $dest_abs"
+            if ! "$GIT_BIN" clone "$url" "$dest_abs"; then
+                print_fail "$name: git clone failed"; record_repo "$name" FAIL "git clone failed"; return 1
+            fi
+        fi
+        branch_now="$("$GIT_BIN" -C "$dest_abs" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")"
+        print_pass "$name cloned" "$dest_abs (branch: $branch_now)"
+    fi
+
+    # --- Verify the repo is uv-native ---
+    if [ ! -f "$dest_abs/pyproject.toml" ]; then
+        print_fail "$name: no pyproject.toml (not a uv-native repo)"
+        record_repo "$name" FAIL "no pyproject.toml"
+        return 1
+    fi
+    [ ! -f "$dest_abs/uv.lock" ] && print_warn "$name: no uv.lock; uv sync will create one"
+
+    # --- uv sync ---
+    local sync_args
+    sync_args=("sync")
+    [ "$WITH_DEV_DEPS" = 1 ] && sync_args+=("--extra" "dev")
+    local do_sync=1
+    if [ "$PER_STEP" = 1 ]; then
+        printf "  Will run: uv %s  (in %s)\n" "${sync_args[*]}" "$dest_abs"
+        prompt_yn "Run uv sync now?" y || do_sync=0
+    fi
+    if [ "$do_sync" = 0 ]; then
+        print_fail "$name: uv sync declined"
+        record_repo "$name" FAIL "uv sync declined"
+        return 1
+    fi
+    echo_cmd "uv ${sync_args[*]}  (cwd: $dest_abs)"
+    if ! ( cd "$dest_abs" && "$UV_BIN" "${sync_args[@]}" ); then
+        print_fail "$name: uv sync failed"
+        record_repo "$name" FAIL "uv sync failed"
+        return 1
+    fi
+    print_pass "$name installed (uv sync)"
+
+    # --- Verify import ---
+    local venv_py="$dest_abs/.venv/bin/python"
+    if [ ! -x "$venv_py" ]; then
+        print_fail "$name: venv python not found" "$venv_py"
+        record_repo "$name" FAIL "no venv python"
+        return 1
+    fi
+    if "$venv_py" -W ignore -c "import $pkg" >/dev/null 2>&1; then
+        local ver
+        ver="$("$venv_py" -W ignore -c "import $pkg; print(getattr($pkg, '__version__', '?'))" 2>/dev/null || echo '?')"
+        print_pass "$name: import $pkg" "$ver"
+        if [ "$repo_state" = "WARN" ]; then
+            record_repo "$name" WARN "import $pkg ($ver); pull warning"
+        else
+            record_repo "$name" PASS "import $pkg ($ver)"
+        fi
+        return 0
+    else
+        print_fail "$name: import $pkg failed" "package not importable; check log above"
+        record_repo "$name" FAIL "import $pkg failed"
+        return 1
+    fi
+}
+
+# ── Resolve the list of repos to install ──────────────────────────────────────
+# Each TARGETS entry: OWNER|NAME|PKG|DESC|URL
+TARGETS=()
+if [ -n "$REPO_URL" ]; then
+    if [ "$INSTALL_ALL" = 1 ] || [ "${#SELECTED_KEYS[@]}" -gt 0 ]; then
+        err "--repo-url installs a single repo; it cannot be combined with --all or --repo."
+    fi
+    base="$(basename "$REPO_URL")"
+    cu_name="${base%.git}"
+    cu_pkg="$(printf '%s' "$cu_name" | tr '[:upper:]' '[:lower:]' | tr -d '-')"
+    TARGETS+=("(custom URL)|$cu_name|$cu_pkg|custom repo|$REPO_URL")
+elif [ "$INSTALL_ALL" = 1 ]; then
+    if [ "${#SELECTED_KEYS[@]}" -gt 0 ]; then
+        err "--all installs every repo; do not also pass --repo."
+    fi
+    for entry in "${REPOS[@]}"; do
+        IFS='|' read -r k owner name pkg desc <<< "$entry"
+        TARGETS+=("$owner|$name|$pkg|$desc|https://github.com/$owner/$name.git")
+    done
+elif [ "${#SELECTED_KEYS[@]}" -gt 0 ]; then
+    seen=" "
+    for key in "${SELECTED_KEYS[@]}"; do
+        case "$seen" in *" $key "*) continue;; esac
+        seen="$seen$key "
+        if lookup_repo "$key"; then
+            TARGETS+=("$REPO_OWNER|$REPO_NAME|$PKG_NAME|$REPO_DESC|https://github.com/$REPO_OWNER/$REPO_NAME.git")
+        else
+            err "unknown --repo '$key'. Run --list to see valid keys."
+        fi
+    done
 else
     choose_repo_interactive
+    if [ -n "$REPO_URL" ]; then
+        base="$(basename "$REPO_URL")"
+        cu_name="${base%.git}"
+        cu_pkg="$(printf '%s' "$cu_name" | tr '[:upper:]' '[:lower:]' | tr -d '-')"
+        TARGETS+=("(custom URL)|$cu_name|$cu_pkg|custom repo|$REPO_URL")
+    else
+        TARGETS+=("$REPO_OWNER|$REPO_NAME|$PKG_NAME|$REPO_DESC|https://github.com/$REPO_OWNER/$REPO_NAME.git")
+    fi
 fi
 
-# Custom URL: derive repo name + package name from it.
-if [ -n "$REPO_URL" ] && [ -z "${REPO_NAME:-}" ]; then
-    base="$(basename "$REPO_URL")"
-    REPO_NAME="${base%.git}"
-    REPO_OWNER="(custom URL)"
-    REPO_DESC="custom repo"
-    PKG_NAME="$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]' | tr -d '-')"
-    REPO_KEY="$PKG_NAME"
+TOTAL_TARGETS="${#TARGETS[@]}"
+if [ -n "$BRANCH" ] && [ "$TOTAL_TARGETS" -gt 1 ]; then
+    err "--branch can only be used with a single repo (selected: $TOTAL_TARGETS)."
 fi
+# One repo keeps the per-step confirmations; multiple run as a batch.
+PER_STEP=1; [ "$TOTAL_TARGETS" -gt 1 ] && PER_STEP=0
 
-if [ -z "$REPO_URL" ]; then
-    REPO_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}.git"
-fi
-
-# ── Pick destination (PARENT directory; clone lands at PARENT/REPO_NAME) ──────
+# ── Pick destination (PARENT directory; each repo lands at PARENT/REPO_NAME) ──
 if [ -z "$DEST" ]; then
     if [ ! -t 0 ]; then
         DEST="."
     else
-        printf "\n  Where would you like to install %s?\n" "$REPO_NAME"
-        printf "  Enter the PARENT directory; %s will be cloned as a subfolder inside.\n" "$REPO_NAME"
+        printf "\n  Where would you like to install?\n"
+        printf "  Enter the PARENT directory; each repo is cloned into its own subfolder.\n"
         printf "  Default: current directory (%s)\n" "$(pwd)"
         printf "  Parent directory [.]: "
         IFS= read -r DEST || true
@@ -304,16 +536,14 @@ case "$DEST" in
     "~/"*) DEST="$HOME/${DEST#~/}";;
 esac
 
-# DEST is the parent directory. Must exist; resolve to absolute.
 if [ ! -d "$DEST" ]; then
     printf "${RED}ERROR:${RESET} parent directory does not exist: %s\n" "$DEST" >&2
     printf "Create it first (mkdir -p %s) or pick a different --dest.\n" "$DEST" >&2
     exit 1
 fi
 PARENT_ABS="$(cd "$DEST" && pwd)"
-DEST_ABS="${PARENT_ABS}/${REPO_NAME}"
 
-# Refuse if PARENT is a dangerous system dir. (User-home is fine -- clone lands
+# Refuse if PARENT is a dangerous system dir. (User-home is fine -- clones land
 # inside it, not overwriting it.)
 case "$PARENT_ABS" in
     "/"|"/usr"|"/etc"|"/var"|"/bin"|"/sbin"|"/opt")
@@ -327,12 +557,8 @@ hr_thick
 printf "  ${BOLD}OG-* Installer (uv-based)${RESET}\n"
 hr_thick
 printf "  Platform     : %s %s\n" "$OS_NAME" "$(uname -m)"
-printf "  Model        : %s\n" "$REPO_NAME"
-printf "  Description  : %s\n" "$REPO_DESC"
-printf "  Source       : %s\n" "$REPO_URL"
+printf "  Destination  : %s\n" "$PARENT_ABS"
 [ -n "$BRANCH" ] && printf "  Branch       : %s\n" "$BRANCH"
-printf "  Destination  : %s\n" "$DEST_ABS"
-printf "  Package      : %s\n" "$PKG_NAME"
 printf "  Dev/test deps: %s\n" "$([ "$WITH_DEV_DEPS" = 1 ] && echo yes || echo no)"
 if [ "$UV_PRESENT" = 1 ]; then
     printf "  uv           : %s ${GREEN}detected${RESET}\n" "$UV_BIN"
@@ -341,36 +567,36 @@ else
 fi
 [ "$WRITE_LOG" = 1 ] && printf "  Log file     : %s\n" "$LOG_FILE"
 echo
-printf "  ${BOLD}Plan (%d steps):${RESET}\n" "$TOTAL_STEPS"
-if [ "$UV_PRESENT" = 1 ] || [ "$SKIP_UV_INSTALL" = 1 ]; then
-    printf "    1. Install uv                      ${DIM}skipped${RESET}\n"
-else
-    printf "    1. Install uv                      ${DIM}~5MB, seconds${RESET}\n"
-fi
-printf "    2. Clone %-25s ${DIM}depends on network${RESET}\n" "$REPO_NAME"
-printf "    3. uv sync (Python + deps)         ${DIM}~30s, ~500MB${RESET}\n"
-printf "    4. Verify installation             ${DIM}a few seconds${RESET}\n"
+printf "  ${BOLD}Repos to install (%d):${RESET}\n" "$TOTAL_TARGETS"
+for t in "${TARGETS[@]}"; do
+    IFS='|' read -r t_owner t_name t_pkg t_desc t_url <<< "$t"
+    printf "    - %-9s ${DIM}%s${RESET} -> %s/%s\n" "$t_name" "$t_desc" "$PARENT_ABS" "$t_name"
+done
 echo
-printf "  You will be asked to confirm before each mutating step.\n"
+printf "  Each repo: clone, uv sync (Python + deps, ~30s/~500MB), verify import.\n"
+if [ "$PER_STEP" = 1 ]; then
+    printf "  You will be asked to confirm before each mutating step.\n"
+else
+    printf "  ${BOLD}%d repos${RESET} will be installed after one confirmation below.\n" "$TOTAL_TARGETS"
+fi
 echo
 
-if ! prompt_yn "Proceed with installation?" y; then
+proceed_prompt="Proceed with installation?"
+[ "$TOTAL_TARGETS" -gt 1 ] && proceed_prompt="Proceed with installing $TOTAL_TARGETS repos?"
+if ! prompt_yn "$proceed_prompt" y; then
     printf "${YELLOW}Aborted by user.${RESET}\n"; exit 0
 fi
 
-# ── Result tracking ───────────────────────────────────────────────────────────
-declare -a STEP_NAMES=() STEP_STATES=() STEP_DETAILS=()
-record_step() { STEP_NAMES+=("$1"); STEP_STATES+=("$2"); STEP_DETAILS+=("$3"); }
 START_TS=$(date +%s)
 
-# ── Step 1: Install uv ────────────────────────────────────────────────────────
-step_banner 1 "Install uv"
+# ── Install uv (once, shared by all repos) ────────────────────────────────────
+section "Install uv"
+UV_STATE="PASS"; UV_DETAIL=""
 if [ "$UV_PRESENT" = 1 ]; then
     print_pass "uv already present" "$UV_BIN"
-    record_step "uv" SKIP "already present"
+    UV_STATE="SKIP"; UV_DETAIL="already present"
 elif [ "$SKIP_UV_INSTALL" = 1 ]; then
     print_fail "--skip-uv-install given but no uv found"
-    record_step "uv" FAIL "no uv and --skip-uv-install"
     exit 1
 else
     printf "  Will install uv via the official installer:\n"
@@ -379,7 +605,6 @@ else
     printf "    Method : curl | sh -- no sudo, installs to your home directory.\n"
     echo
     if ! prompt_yn "Download and install uv?" y; then
-        record_step "uv" SKIP "declined"
         printf "${RED}Cannot continue without uv. Aborting.${RESET}\n"; exit 1
     fi
     echo_cmd "curl -LsSf https://astral.sh/uv/install.sh | sh"
@@ -392,127 +617,19 @@ else
     fi
     if [ -z "$UV_BIN" ] || [ ! -x "$UV_BIN" ]; then
         print_fail "uv install completed but binary not found"
-        record_step "uv" FAIL "binary not found post-install"
         exit 1
     fi
     print_pass "uv installed" "$UV_BIN ($("$UV_BIN" --version 2>/dev/null | head -1))"
-    record_step "uv" PASS "$UV_BIN"
+    UV_DETAIL="$UV_BIN"
 fi
 
-# ── Step 2: Clone the repo ────────────────────────────────────────────────────
-step_banner 2 "Clone ${REPO_NAME}"
-
-DEST_HAS_REPO=0; DEST_EMPTY=0
-if [ -d "$DEST_ABS" ]; then
-    if [ -z "$(ls -A "$DEST_ABS" 2>/dev/null || true)" ]; then
-        DEST_EMPTY=1
-    elif [ -d "$DEST_ABS/.git" ]; then
-        existing_url="$("$GIT_BIN" -C "$DEST_ABS" config --get remote.origin.url 2>/dev/null || true)"
-        norm() { printf '%s' "$1" | sed -E 's#\.git/?$##' | tr '[:upper:]' '[:lower:]'; }
-        if [ "$(norm "$existing_url")" = "$(norm "$REPO_URL")" ]; then
-            DEST_HAS_REPO=1
-        else
-            print_fail "Destination is a git repo for a different remote" "$existing_url"
-            printf "  Either remove %s or pick a different destination with --dest.\n" "$DEST_ABS"
-            record_step "Clone" FAIL "wrong remote"; exit 1
-        fi
-    else
-        print_fail "Destination exists and is not empty (and not a git clone)" "$DEST_ABS"
-        printf "  Either remove %s or pick a different destination with --dest.\n" "$DEST_ABS"
-        record_step "Clone" FAIL "destination not empty"; exit 1
-    fi
-fi
-
-if [ "$DEST_HAS_REPO" = 1 ]; then
-    branch="$("$GIT_BIN" -C "$DEST_ABS" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")"
-    printf "  Existing clone of %s found at %s (branch: %s).\n" "$REPO_NAME" "$DEST_ABS" "$branch"
-    printf "  Will run 'git pull --ff-only' to bring it up to date.\n"
-    echo
-    if prompt_yn "Update existing clone?" y; then
-        echo_cmd "git -C $DEST_ABS pull --ff-only"
-        if "$GIT_BIN" -C "$DEST_ABS" pull --ff-only; then
-            print_pass "Repo updated" "$DEST_ABS"
-            record_step "Clone" PASS "updated ($branch)"
-        else
-            print_warn "git pull failed; continuing with existing state"
-            record_step "Clone" WARN "pull failed; existing state used"
-        fi
-    else
-        print_skip "Update" "using existing clone as-is"
-        record_step "Clone" SKIP "existing clone used as-is ($branch)"
-    fi
-else
-    if [ -n "$BRANCH" ]; then
-        printf "  Will clone %s (branch: %s) into %s.\n" "$REPO_URL" "$BRANCH" "$DEST_ABS"
-    else
-        printf "  Will clone %s into %s.\n" "$REPO_URL" "$DEST_ABS"
-    fi
-    echo
-    if prompt_yn "Clone now?" y; then
-        if [ -n "$BRANCH" ]; then
-            echo_cmd "git clone --branch $BRANCH $REPO_URL $DEST_ABS"
-            "$GIT_BIN" clone --branch "$BRANCH" "$REPO_URL" "$DEST_ABS"
-        else
-            echo_cmd "git clone $REPO_URL $DEST_ABS"
-            "$GIT_BIN" clone "$REPO_URL" "$DEST_ABS"
-        fi
-        branch="$("$GIT_BIN" -C "$DEST_ABS" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")"
-        print_pass "Cloned" "$DEST_ABS (branch: $branch)"
-        record_step "Clone" PASS "$branch"
-    else
-        print_fail "Clone declined; cannot continue."
-        record_step "Clone" FAIL "declined"; exit 1
-    fi
-fi
-
-# Verify the repo is uv-native (has pyproject.toml and uv.lock).
-if [ ! -f "$DEST_ABS/pyproject.toml" ]; then
-    print_fail "$DEST_ABS has no pyproject.toml"
-    printf "  This installer requires repos that have migrated to uv.\n"
-    record_step "Clone" FAIL "no pyproject.toml"; exit 1
-fi
-if [ ! -f "$DEST_ABS/uv.lock" ]; then
-    print_warn "$DEST_ABS has no uv.lock; uv sync will create one"
-fi
-
-# ── Step 3: uv sync ───────────────────────────────────────────────────────────
-step_banner 3 "Install ${REPO_NAME} (uv sync)"
-sync_args=("sync")
-[ "$WITH_DEV_DEPS" = 1 ] && sync_args+=("--extra" "dev")
-printf "  Will install %s + Python + all deps into %s/.venv\n" "$REPO_NAME" "$DEST_ABS"
-printf "  Working directory : %s\n" "$DEST_ABS"
-printf "  Command           : uv %s\n" "${sync_args[*]}"
-echo
-if prompt_yn "Run uv sync now?" y; then
-    cd "$DEST_ABS"
-    echo_cmd "uv ${sync_args[*]}"
-    "$UV_BIN" "${sync_args[@]}"
-    print_pass "${REPO_NAME} installed (editable)"
-    record_step "${REPO_NAME} install" PASS "uv sync"
-else
-    print_fail "uv sync declined; package will not be importable."
-    record_step "${REPO_NAME} install" FAIL "declined"
-fi
-
-# ── Step 4: Verify ────────────────────────────────────────────────────────────
-step_banner 4 "Verify installation"
-if [ ! -x "$DEST_ABS/.venv/bin/python" ]; then
-    print_fail "Venv python not found; skipping import check." "$DEST_ABS/.venv/bin/python"
-    record_step "Verification" FAIL "no venv python"
-else
-    # -W ignore silences upstream deprecation warnings (e.g. from pygam) so
-    # the verification output stays clean.
-    pyver="$("$DEST_ABS/.venv/bin/python" -W ignore -c 'import sys; print(sys.version.split()[0])' 2>/dev/null || echo unknown)"
-    print_pass "Python in .venv" "$pyver"
-    if "$DEST_ABS/.venv/bin/python" -W ignore -c "import $PKG_NAME" >/dev/null 2>&1; then
-        ver="$("$DEST_ABS/.venv/bin/python" -W ignore -c "import $PKG_NAME; print(getattr($PKG_NAME, '__version__', '?'))" 2>/dev/null)"
-        print_pass "import $PKG_NAME" "$ver"
-        record_step "Verification" PASS "import $PKG_NAME ($ver)"
-    else
-        print_fail "import $PKG_NAME" "package not importable; check log above"
-        record_step "Verification" FAIL "import $PKG_NAME failed"
-    fi
-fi
+# ── Install each repo (continue on failure) ───────────────────────────────────
+i=0
+for t in "${TARGETS[@]}"; do
+    i=$((i + 1))
+    IFS='|' read -r t_owner t_name t_pkg t_desc t_url <<< "$t"
+    install_one_repo "$t_owner" "$t_name" "$t_pkg" "$t_desc" "$t_url" "$i" "$TOTAL_TARGETS" || true
+done
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 END_TS=$(date +%s); ELAPSED=$((END_TS - START_TS))
@@ -520,41 +637,41 @@ ELAPSED_MIN=$((ELAPSED / 60)); ELAPSED_SEC=$((ELAPSED % 60))
 
 echo
 hr_thick
-printf "  ${BOLD}Installation Summary -- %s${RESET}\n" "$REPO_NAME"
+printf "  ${BOLD}Installation Summary${RESET}\n"
 hr_thick
+case "$UV_STATE" in
+    PASS) print_pass "uv" "$UV_DETAIL";;
+    SKIP) print_skip "uv" "$UV_DETAIL";;
+    *)    print_warn "uv" "$UV_DETAIL";;
+esac
 all_ok=1
-for i in "${!STEP_NAMES[@]}"; do
-    name="${STEP_NAMES[$i]}"; state="${STEP_STATES[$i]}"; detail="${STEP_DETAILS[$i]}"
+for idx in "${!REPO_RESULT_NAMES[@]}"; do
+    name="${REPO_RESULT_NAMES[$idx]}"; state="${REPO_RESULT_STATES[$idx]}"; detail="${REPO_RESULT_DETAILS[$idx]}"
     case "$state" in
         PASS) print_pass "$name" "$detail";;
-        SKIP) print_skip "$name" "$detail";;
         WARN) print_warn "$name" "$detail";;
+        SKIP) print_skip "$name" "$detail";;
         FAIL) print_fail "$name" "$detail"; all_ok=0;;
-        *)    print_warn "$name" "unknown: $state";;
+        *)    print_warn "$name" "unknown: $state"; all_ok=0;;
     esac
 done
 echo
 printf "  Elapsed  : %dm %ds\n" "$ELAPSED_MIN" "$ELAPSED_SEC"
-printf "  Location : %s\n" "$DEST_ABS"
-printf "  Venv     : %s/.venv\n" "$DEST_ABS"
+printf "  Location : %s\n" "$PARENT_ABS"
 [ "$WRITE_LOG" = 1 ] && printf "  Log      : %s\n" "$LOG_FILE"
 echo
 
 if [ "$all_ok" = 1 ]; then
-    printf "  ${GREEN}${BOLD}All steps completed successfully.${RESET}\n"
+    printf "  ${GREEN}${BOLD}All repos installed successfully.${RESET}\n"
     echo
-    printf "  ${BOLD}To start using ${REPO_NAME}:${RESET}\n"
-    printf "    cd %s\n" "$DEST_ABS"
-    printf "    source .venv/bin/activate         # activate venv\n"
-    printf "    python -W ignore -c \"import %s; print(%s.__file__)\"\n" "$PKG_NAME" "$PKG_NAME"
-    printf "  Or run commands without activating:\n"
-    printf "    uv run python -W ignore -c \"import %s; print(%s.__file__)\"\n" "$PKG_NAME" "$PKG_NAME"
-    if [ -d "$DEST_ABS/examples" ]; then
-        printf "\n  Example scripts: %s/examples\n" "$DEST_ABS"
-    fi
+    printf "  ${BOLD}To start using them:${RESET}\n"
+    for idx in "${!REPO_RESULT_NAMES[@]}"; do
+        name="${REPO_RESULT_NAMES[$idx]}"
+        printf "    cd %s/%s && source .venv/bin/activate\n" "$PARENT_ABS" "$name"
+    done
     exit 0
 else
-    printf "  ${RED}${BOLD}One or more steps failed.${RESET}\n"
+    printf "  ${RED}${BOLD}One or more repos failed.${RESET}\n"
     echo
     printf "  Review the [FAIL] entries above.\n"
     [ "$WRITE_LOG" = 1 ] && printf "  Full output is in: %s\n" "$LOG_FILE"

--- a/scripts/repos.json
+++ b/scripts/repos.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "repos": [
+    {
+      "key": "og-core",
+      "owner": "PSLmodels",
+      "repo": "OG-Core",
+      "package": "ogcore",
+      "description": "base model (no country calibration)"
+    },
+    {
+      "key": "og-eth",
+      "owner": "EAPD-DRB",
+      "repo": "OG-ETH",
+      "package": "ogeth",
+      "description": "Ethiopia"
+    },
+    {
+      "key": "og-zaf",
+      "owner": "EAPD-DRB",
+      "repo": "OG-ZAF",
+      "package": "ogzaf",
+      "description": "South Africa"
+    },
+    {
+      "key": "og-idn",
+      "owner": "EAPD-DRB",
+      "repo": "OG-IDN",
+      "package": "ogidn",
+      "description": "Indonesia"
+    },
+    {
+      "key": "og-phl",
+      "owner": "EAPD-DRB",
+      "repo": "OG-PHL",
+      "package": "ogphl",
+      "description": "Philippines"
+    }
+  ]
+}


### PR DESCRIPTION
Builds on the universal installer (#1142). Three additions:

**Install several repos in one run.** `--repo` can be repeated (`--repo og-zaf --repo og-idn`) or take a comma list; `--all` installs the whole catalog. (On Windows, where a parameter can't repeat, use the comma form: `-Repo og-zaf,og-idn`.) Each repo clones into its own subfolder under `--dest` and installs independently — if one fails it's reported and the rest continue, with a per-repo summary at the end. `uv` is installed once. A single repo keeps the existing per-step prompts; multiple run as a batch after one confirmation. `--branch` and `--repo-url` stay single-repo only.

**Expanded catalog.** Adds `og-zaf`, `og-idn`, `og-phl` alongside `og-core`/`og-eth`, now that they're uv-native.

**A reliable way to read the catalog.** `--list` (table) and `--list-json` (JSON) print the catalog and exit, and `scripts/repos.json` publishes the same data as a static file — so downstream tooling can stay in sync by fetching one URL instead of scraping the script or `--help`. A small CI check (`.github/workflows/check_catalog.yml`) fails if `install.sh`, `install.ps1`, and `repos.json` ever drift apart.

Hands-free, unattended use: `bash install.sh --all --dest ~/OG --yes`. `scripts/QUICK_INSTALL.md` is updated for all of the above.

Also tightens a few edges: clean error messages for unknown or missing flag values, and a correct non-zero exit when a non-interactive run can't proceed.

**Tested:** every selection mode on bash 3.2 (the macOS default) — repeated / comma / `--all` / dedup / single, plus the guardrail errors — all stopping before any real install; the catalog stays in sync via the new CI check. The PowerShell side mirrors the bash logic and its `-ListJson` path runs in CI, but I haven't yet run the full multi-repo install loop on Windows.

cc: @rickecon @jdebacker
