### PR TITLE
Extend alpha_FA to the model time path

### DIFF
--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -956,9 +956,9 @@
     },
     "alpha_FA": {
         "title": "Foreign aid payments to domestic government as a share of GDP",
-        "description": "Foreign aid payments to domestic government as a share of GDP.",
+        "description": "Foreign aid payments to domestic government as a share of GDP. Set value for base year, click '+' to add value for next year.  All future years not specified are set to last value entered.",
         "short_description": "Foreign aid as a share of GDP",
-        "param_notation": "$\\alpha_{FA}$",
+        "param_notation": "$\\alpha_{FA,t}$",
         "section_1": "Fiscal Policy Parameters",
         "section_2": "Fiscal Policy Parameters",
         "notes": "",

--- a/ogcore/parameters.py
+++ b/ogcore/parameters.py
@@ -181,6 +181,7 @@ class Specifications(paramtools.Parameters):
             "alpha_G",
             "alpha_T",
             "alpha_I",
+            "alpha_FA",
             "alpha_bs_G",
             "alpha_bs_T",
             "alpha_bs_I",

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -36,6 +36,23 @@ def test_compute_default_params():
     assert specs.alpha_G[10] == 1
 
 
+def test_alpha_FA_extended_over_time_path():
+    # alpha_FA is a GDP-share fiscal parameter that may vary over the time
+    # path, so it should be extrapolated to length T+S with the last value
+    # carried forward (like alpha_G/alpha_T/alpha_I).  A multi-element path
+    # previously stayed short and broke the TPI fiscal calculations when
+    # broadcast against Y[:T].
+    specs = Specifications()
+    specs.alpha_FA = np.array([0.01, 0.02, 0.03])
+    specs.compute_default_params()
+    assert specs.alpha_FA.shape[0] == specs.T + specs.S
+    assert specs.alpha_FA[0] == 0.01
+    assert specs.alpha_FA[2] == 0.03
+    # periods beyond the entered path take the last value entered
+    assert specs.alpha_FA[specs.T] == 0.03
+    assert specs.alpha_FA[-1] == 0.03
+
+
 param_updates1 = {
     "T": 4,
     "S": 3,


### PR DESCRIPTION
`alpha_FA` was added in 0.16.0 but never added to the list of parameters that get extended over the time path, so unlike `alpha_G`/`alpha_T`/`alpha_I` you can't give it a multi-year path. A single value works by accident (it broadcasts); any real path stays short and breaks the transition solve when the fiscal code multiplies it by `Y[:T]`.

Fix is to register it in `tp_param_list` so it extends to `T+S` with the last value carried forward. Nothing else needed — SS and TPI already index it like `alpha_G` (`[-1]` for the steady state, `[:T]` on the path). Also updated its description in `default_parameters.json` to note it can vary over time, and added a test.

Scalar `alpha_FA` gives a constant path, so existing runs are unchanged. `test_parameters.py` and `test_fiscal.py` pass, ruff clean.

cc: @jdebacker @rickecon
