### PR TITLE
Use capital income tax noncompliance rate in SS etr/mtry diagnostics

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -913,7 +913,7 @@ def SS_solver(
         (p.S, 1),
     )
     capital_noncompliance_rate_2D = np.tile(
-        np.reshape(p.labor_income_tax_noncompliance_rate[-1, :], (1, p.J)),
+        np.reshape(p.capital_income_tax_noncompliance_rate[-1, :], (1, p.J)),
         (p.S, 1),
     )
     income_tax_filer_2D = np.tile(


### PR DESCRIPTION
Fixes #1170.

One-word fix: `capital_noncompliance_rate_2D` in `SS.py` was tiled from `p.labor_income_tax_noncompliance_rate` instead of `p.capital_income_tax_noncompliance_rate`. This only affects the post-solve `etr_ss` and `mtry_ss` diagnostics in the SS output — the solution itself uses the correct rates via `household.py` and `tax.py`. No behavior change when the two rates are equal (the default).

Happy to add a changelog entry and version bump if you'd like them in this PR.
