### PR TITLE
Add OG-BRA (Brazil) to the installer catalog

### DIFF
--- a/scripts/QUICK_INSTALL.md
+++ b/scripts/QUICK_INSTALL.md
@@ -50,6 +50,7 @@ By default the installer shows a menu of repos and prompts for a destination. Fl
   - `og-zaf` — South Africa ([EAPD-DRB/OG-ZAF](https://github.com/EAPD-DRB/OG-ZAF))
   - `og-idn` — Indonesia ([EAPD-DRB/OG-IDN](https://github.com/EAPD-DRB/OG-IDN))
   - `og-phl` — Philippines ([EAPD-DRB/OG-PHL](https://github.com/EAPD-DRB/OG-PHL))
+  - `og-bra` — Brazil ([PSLmodels/OG-BRA](https://github.com/PSLmodels/OG-BRA))
 - `--all` / `-All` — install every repo in the catalog (each into its own subfolder).
 - `--list` / `-List` and `--list-json` / `-ListJson` — print the repo catalog (human-readable or JSON) and exit, without installing anything. The same catalog is also published as a static file you can fetch directly: [`scripts/repos.json`](repos.json).
 - `--repo-url` / `-RepoUrl` — a full git URL for a single custom repo (a fork, or a country repo not yet in the catalog). Clones the default branch.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -91,7 +91,8 @@ $Repos = @(
     [pscustomobject]@{ Key="og-eth";  Owner="EAPD-DRB";  Name="OG-ETH";  Pkg="ogeth";  Desc="Ethiopia" },
     [pscustomobject]@{ Key="og-zaf";  Owner="EAPD-DRB";  Name="OG-ZAF";  Pkg="ogzaf";  Desc="South Africa" },
     [pscustomobject]@{ Key="og-idn";  Owner="EAPD-DRB";  Name="OG-IDN";  Pkg="ogidn";  Desc="Indonesia" },
-    [pscustomobject]@{ Key="og-phl";  Owner="EAPD-DRB";  Name="OG-PHL";  Pkg="ogphl";  Desc="Philippines" }
+    [pscustomobject]@{ Key="og-phl";  Owner="EAPD-DRB";  Name="OG-PHL";  Pkg="ogphl";  Desc="Philippines" },
+    [pscustomobject]@{ Key="og-bra";  Owner="PSLmodels"; Name="OG-BRA";  Pkg="ogbra";  Desc="Brazil" }
 )
 
 # -- Catalog listing (-List / -ListJson) ---------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,6 +31,7 @@ REPOS=(
     "og-zaf|EAPD-DRB|OG-ZAF|ogzaf|South Africa"
     "og-idn|EAPD-DRB|OG-IDN|ogidn|Indonesia"
     "og-phl|EAPD-DRB|OG-PHL|ogphl|Philippines"
+    "og-bra|PSLmodels|OG-BRA|ogbra|Brazil"
 )
 
 # ── Defaults ──────────────────────────────────────────────────────────────────

--- a/scripts/repos.json
+++ b/scripts/repos.json
@@ -35,6 +35,13 @@
       "repo": "OG-PHL",
       "package": "ogphl",
       "description": "Philippines"
+    },
+    {
+      "key": "og-bra",
+      "owner": "PSLmodels",
+      "repo": "OG-BRA",
+      "package": "ogbra",
+      "description": "Brazil"
     }
   ]
 }


### PR DESCRIPTION
This adds OG-BRA, the Brazil calibration, to the universal installer's catalog. With this, `--repo og-bra` works and Brazil shows up in the installer's interactive menu, same as the other country models. OG-BRA moved to uv in PSLmodels/OG-BRA#5, so it meets the catalog's only requirement.

Tested locally on macOS: `bash scripts/install.sh --repo og-bra --dest <tmp> --yes` cloned, synced, and import-verified ogbra in about 30 seconds, and `--list-json` matches `scripts/repos.json`. I don't have PowerShell on this machine, so the install.ps1 side rides on the check_catalog CI job.