### PR TITLE
Default income_percentiles to a single group in the homogeneous case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -685,6 +685,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.18.1]: https://github.com/PSLmodels/OG-Core/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/PSLmodels/OG-Core/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/PSLmodels/OG-Core/compare/v0.16.4...v0.17.0
 [0.16.4]: https://github.com/PSLmodels/OG-Core/compare/v0.16.3...v0.16.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-07-22 12:00:00
+
+### Bug Fixes
+
+- Fixes Issue [#1180](https://github.com/PSLmodels/OG-Core/issues/1180):
+  `get_pop_objs` raised an `AssertionError` for the homogeneous case
+  (`income_percentiles=None` with no income-specific inputs), because
+  `expand_pop_obj_J` asserted before reaching its homogeneous branch.
+  `income_percentiles` now defaults to a single income group (J=1) when
+  no income-specific inputs are supplied, restoring the pre-0.18 call
+  signature; it remains required whenever gradients or immigrant income
+  shares are provided. Also removes a stray debug `print` from that
+  branch.
+
 ## [0.18.0] - 2026-07-20 12:00:00
 
 ### Added

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -21,4 +21,4 @@ from ogcore.tax import *  # noqa: F403
 from ogcore.txfunc import *  # noqa: F403
 from ogcore.utils import *  # noqa: F403
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -901,9 +901,10 @@ def expand_pop_obj_J(
 
     The aggregate population path and rates are left unchanged. If
     income_percentiles is None and no income-specific inputs are
-    provided, the original aggregate objects are returned. Otherwise,
-    income_percentiles gives the initial population distribution across
-    J for every age and the income shares of newborns in every period.
+    provided, the aggregate objects are broadcast across a single
+    income group (J=1). Otherwise, income_percentiles gives the initial
+    population distribution across J for every age and the income
+    shares of newborns in every period.
 
     Args:
         omega_path_lev (Numpy array): T+S x E+S aggregate population levels.
@@ -922,7 +923,9 @@ def expand_pop_obj_J(
         g_n_SS (float): steady-state population growth rate.
         fixper (int): period at which the fixed steady-state distribution is
             imposed.
-        income_percentiles (array_like): population shares for each J group.
+        income_percentiles (array_like): population shares for each J
+            group; defaults to a single income group when no
+            income-specific inputs are supplied.
         fert_gradient (array_like): log-odds fertility slopes by age.
         mort_gradient (array_like): log-odds mortality slopes by age.
         infmort_gradient (array_like): log-odds infant mortality slopes.
@@ -939,10 +942,15 @@ def expand_pop_obj_J(
         infmort_gradient,
         imm_pctiles,
     )
-    assert income_percentiles is not None, (
-        "income_percentiles must be provided when using "
-        + "income-specific inputs."
-    )
+    all_income_inputs_none = all(x is None for x in income_inputs)
+    if income_percentiles is None:
+        assert all_income_inputs_none, (
+            "income_percentiles must be provided when using "
+            + "income-specific inputs."
+        )
+        # No income heterogeneity requested: broadcast the aggregate
+        # objects across a single income group.
+        income_percentiles = [100]
     income_shares, pct_midpoints = _income_shares_and_midpoints(
         income_percentiles
     )
@@ -950,10 +958,7 @@ def expand_pop_obj_J(
     num_periods, totpers = omega_path_lev.shape
     assert totpers == E + S
 
-    all_income_inputs_none = all(x is None for x in income_inputs)
-
     if all_income_inputs_none:
-        print("In the all are none case.")
         return {
             "omega_path_S": omega_path_S.reshape(
                 omega_path_S.shape[0], omega_path_S.shape[1], 1
@@ -1147,7 +1152,9 @@ def get_pop_objs(
             for new immigrants, shape is num_per x S x J, where num_per
             is the number of years between initial and final_data_year
         income_percentiles (array_like): user provided income percentiles,
-            dimensions are J, the number of lifetime income groups
+            dimensions are J, the number of lifetime income groups;
+            defaults to a single income group (J=1) when no
+            income-specific inputs are supplied
         country_id (str): country id for UN data
         initial_data_year (int): initial year of data to use
             (not relevant if have user provided data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ogcore"
-version = "0.18.0"
+version = "0.18.1"
 authors = [
     {name = "Jason DeBacker and Richard W. Evans"},
 ]

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -668,6 +668,96 @@ def test_expand_pop_obj_J_tiles_when_no_income_inputs():
     )
 
 
+def test_expand_pop_obj_J_defaults_to_single_group():
+    """
+    Regression test for Issue #1180: with income_percentiles=None and no
+    income-specific inputs (the pre-0.18 call signature), the aggregate
+    objects must be broadcast across a single income group rather than
+    raising an AssertionError.
+    """
+    E = 1
+    S = 3
+    num_periods = 5
+    fixper = 2
+    omega_SSfx = np.array([0.2, 0.3, 0.3, 0.2])
+    omega_path_lev = np.tile(omega_SSfx.reshape(1, E + S), (num_periods, 1))
+    omega_path_S = omega_path_lev[:, E:] / omega_path_lev[:, E:].sum(
+        axis=1
+    ).reshape(num_periods, 1)
+    fert_rates = np.zeros((num_periods, E + S))
+    mort_rates = np.tile(
+        np.array([0.01, 0.02, 0.03, 1.0]).reshape(1, E + S),
+        (num_periods, 1),
+    )
+    infmort_rates = np.ones(num_periods) * 0.005
+    imm_rates = np.zeros((num_periods, E + S))
+    mort_rates_S = mort_rates[:, E:]
+    imm_rates_mat = imm_rates[:, E:]
+
+    pop_objs = demographics.expand_pop_obj_J(
+        omega_path_lev,
+        omega_path_S,
+        omega_SSfx,
+        fert_rates,
+        mort_rates,
+        infmort_rates,
+        imm_rates,
+        mort_rates_S,
+        imm_rates_mat,
+        E,
+        S,
+        0.0,
+        fixper,
+    )
+
+    assert pop_objs["omega_path_S"].shape == (num_periods, S, 1)
+    assert np.allclose(pop_objs["omega_path_S"][:, :, 0], omega_path_S)
+    assert pop_objs["omega_SS"].shape == (S, 1)
+    assert np.allclose(pop_objs["mort_rates_S"][:, :, 0], mort_rates_S)
+    assert np.allclose(pop_objs["imm_rates_mat"][:, :, 0], imm_rates_mat)
+
+
+def test_expand_pop_obj_J_income_inputs_require_percentiles():
+    """
+    income_percentiles stays required when income-specific inputs are
+    supplied: providing a gradient without percentiles must raise.
+    """
+    E = 1
+    S = 3
+    num_periods = 5
+    fixper = 2
+    omega_SSfx = np.array([0.2, 0.3, 0.3, 0.2])
+    omega_path_lev = np.tile(omega_SSfx.reshape(1, E + S), (num_periods, 1))
+    omega_path_S = omega_path_lev[:, E:] / omega_path_lev[:, E:].sum(
+        axis=1
+    ).reshape(num_periods, 1)
+    fert_rates = np.zeros((num_periods, E + S))
+    mort_rates = np.tile(
+        np.array([0.01, 0.02, 0.03, 1.0]).reshape(1, E + S),
+        (num_periods, 1),
+    )
+    infmort_rates = np.ones(num_periods) * 0.005
+    imm_rates = np.zeros((num_periods, E + S))
+
+    with pytest.raises(AssertionError, match="income_percentiles"):
+        demographics.expand_pop_obj_J(
+            omega_path_lev,
+            omega_path_S,
+            omega_SSfx,
+            fert_rates,
+            mort_rates,
+            infmort_rates,
+            imm_rates,
+            mort_rates[:, E:],
+            imm_rates[:, E:],
+            E,
+            S,
+            0.0,
+            fixper,
+            mort_gradient=np.zeros(E + S),
+        )
+
+
 def test_expand_pop_obj_J_preserves_aggregate_mortality_with_gradients():
     """
     Test that log-odds gradients generate bounded J-specific rates whose


### PR DESCRIPTION
Fixes #1180.

## Problem

In 0.18.0, `get_pop_objs` raises an `AssertionError` for the homogeneous case — the pre-0.18 call signature with `income_percentiles=None` and no income-specific inputs — because `expand_pop_obj_J` asserts `income_percentiles is not None` before reaching its own all-inputs-`None` branch. Every downstream caller using the 0.17 signature breaks (OG-UK capped `ogcore<0.18` in PSLmodels/OG-UK#69 pending this fix).

## Fix

`expand_pop_obj_J` now computes `all_income_inputs_none` first; when `income_percentiles is None` it asserts only that no income-specific inputs were supplied, then defaults to a single income group (`[100]`, J=1), broadcasting the aggregate objects as the homogeneous branch intends. `income_percentiles` remains required whenever gradients or immigrant income shares are provided.

Also included:
- removes a stray debug `print("In the all are none case.")` from the homogeneous branch;
- corrects the `expand_pop_obj_J` docstring — the aggregate objects are broadcast to J=1, not "returned" in their original 2-D shapes (`get_pop_objs` indexes three dimensions unconditionally) — and documents the default in both docstrings;
- CHANGELOG entry and version bump to 0.18.1 (happy to drop the bump if you prefer to handle versioning separately).

## Tests

Two synthetic unit tests alongside the existing `expand_pop_obj_J` tests:
- `test_expand_pop_obj_J_defaults_to_single_group` — the pre-0.18 signature returns `(T, S, 1)` objects equal to the aggregates (regression for #1180);
- `test_expand_pop_obj_J_income_inputs_require_percentiles` — a gradient without percentiles still raises.

```
$ pytest tests/test_demographics.py -k expand -q
4 passed, 18 deselected in 1.17s
```

End-to-end, the exact repro from #1180 now succeeds (UK, 2026–2027, GitHub population-data fallback):

```
omega (400, 80, 1) / omega_SS (80, 1) / rho (400, 80, 1) / imm_rates (400, 80, 1); g_n_ss 0.001054
```

`ruff format --check` and `ruff check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
