### PR TITLE
Make SS and TPI output dictionaries expose the same keys

### DIFF
--- a/ogcore/SS.py
+++ b/ogcore/SS.py
@@ -982,7 +982,7 @@ def SS_solver(
         r_p_ss,
         wss,
         bssmat_s,
-        bqssmat,
+        nssmat,
         factor_ss,
         0,
         None,
@@ -1037,6 +1037,10 @@ def SS_solver(
     yss_before_tax_mat = household.get_y(
         r_p_ss, wss, bssmat_s, nssmat, p, "SS"
     )
+    labor_income_ss = (
+        wss * nssmat * np.squeeze(p.e[-1, :, :]).reshape((p.S, p.J))
+    )
+    capital_income_ss = r_p_ss * bssmat_s
     Css = aggr.get_C(cssmat, p, "SS")
     c_i_ss_mat = household.get_ci(
         cssmat, p_i_ss, p_tilde_ss, p.tau_c[-1, :], p.alpha_c, p.c_min
@@ -1224,7 +1228,10 @@ def SS_solver(
         "tr": trssmat,
         "ubi": ubissmat,
         "before_tax_income": yss_before_tax_mat,
+        "labor_income": labor_income_ss,
+        "capital_income": capital_income_ss,
         "hh_net_taxes": taxss,
+        "income_payroll_taxes": income_tax_ss,
         "sales_tax": sales_tax_ss[: p.T, ...],
         "wealth_tax": wealth_tax_ss[: p.T, ...],
         "bequest_tax": bq_tax_ss[: p.T, ...],

--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -1768,6 +1768,8 @@ def run_TPI(p, client=None):
         "etr": etr_path[: p.T, ...],
         "mtrx": mtrx_path[: p.T, ...],
         "mtry": mtry_path[: p.T, ...],
+        "theta": theta,
+        "factor": factor,
         "euler_savings": eul_savings[: p.T, ...],
         "euler_labor_leisure": eul_laborleisure[: p.T, ...],
         "resource_constraint_error": RC_error[: p.T, ...],


### PR DESCRIPTION
Closes #1152.

PR #1005 made the key *names* in the steady-state and transition-path output dictionaries consistent, but the two dictionaries still exposed different sets of keys. This makes the same keys available in both.

Before this PR the differences were:

- In the TPI output but missing from SS: `labor_income`, `capital_income`, `income_payroll_taxes`
- In the SS output but missing from TPI: `factor`, `theta`

Changes:

**SS (`ogcore/SS.py`)**
- Add `labor_income` (`w * n * e`) and `capital_income` (`r_p * b_s`) to the output dict, computed the same way as their TPI counterparts.
- Add `income_payroll_taxes` to the output dict, using the already-computed `income_tax_ss`.
- **Bug fix:** `income_tax_ss` was computed via `tax.income_tax_liab(...)` but passed `bqssmat` (bequests) as the `n` (labor supply) argument. The TPI equivalent (`income_tax_mat`) correctly passes labor supply. `income_tax_ss` was previously never read, so this had no effect until now — but it needs to be correct before it is surfaced in the output. Fixed to pass `nssmat`.

**TPI (`ogcore/TPI.py`)**
- Add `theta` and `factor` to the output dict (both already in scope). These are constants, so they match their SS counterparts.

After the change both dictionaries expose the same 72 keys.

**Testing**
- Verified key parity between the two dictionaries: both now expose the same 72 keys.
- `pytest "tests/test_SS.py::test_SS_solver[Baseline]"` and `pytest "tests/test_TPI.py::test_run_TPI[Baseline]"` both pass, exercising the modified output dictionaries at runtime. These tests iterate over the expected (pickled) keys, so the newly added keys don't affect them and existing values are unchanged.
- `ruff format --check .` and `ruff check .` clean.

Happy to adjust naming/placement or add regression coverage for the new keys if you'd like.
