### PR TITLE
Make NDC pension growth-rate settings parameters so the system can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-07-29 12:00:00
+
+### Added
+
+- Fixes Issue [#1169](https://github.com/PSLmodels/OG-Core/issues/1169):
+  the Notional Defined Contribution pension system could not run against
+  a real `Specifications` object because its growth-rate settings were
+  not parameters. `ndc_growth_rate`, `dir_growth_rate`, and
+  `points_growth_rate` are now parameters in `default_parameters.json`
+  (choices `"r"`, `"Curr GDP"`, `"LR GDP"`; default `"LR GDP"`, matching
+  the previous fallback behavior). `g_ndc` and `g_dir` now handle the
+  scalar `r` and `g_y` of the steady state, and `delta_ret` falls back
+  to the steady-state mortality rates implied by `rho` (averaged over
+  lifetime income groups) when no `mort_rates_SS` attribute is set. The
+  NDC system is added to the real-`Specifications` pension test.
+
 ## [0.18.1] - 2026-07-22 12:00:00
 
 ### Bug Fixes

--- a/docs/book/content/intro/parameters.md
+++ b/docs/book/content/intro/parameters.md
@@ -326,6 +326,20 @@ _Valid Range:_ min = 0.0 and max = 1.0
 _Out-of-Range Action:_ error  
 
 
+####  `ndc_growth_rate`  
+_Description:_ Growth rate applied to contributions under a notional defined contribution system.  
+_Notes:_ 'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.  
+_Value Type:_ str  
+_Valid Choices:_['r', 'Curr GDP', 'LR GDP']  
+
+
+####  `dir_growth_rate`  
+_Description:_ Growth rate used in the conversion coefficient of a notional defined contribution system.  
+_Notes:_ 'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.  
+_Value Type:_ str  
+_Valid Choices:_['r', 'Curr GDP', 'LR GDP']  
+
+
 ####  `alpha_db`  
 _Description:_ Replacement rate under a defined contribution system.  
 _Value Type:_ float  
@@ -338,6 +352,13 @@ _Description:_ The value of a point under a points system pension.
 _Value Type:_ float  
 _Valid Range:_ min = 0.0 and max = 1.0  
 _Out-of-Range Action:_ error  
+
+
+####  `points_growth_rate`  
+_Description:_ Growth rate applied to contributions under a points system pension.  
+_Notes:_ 'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.  
+_Value Type:_ str  
+_Valid Choices:_['r', 'Curr GDP', 'LR GDP']  
 
 
 ####  `yr_contrib`  

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -21,4 +21,4 @@ from ogcore.tax import *  # noqa: F403
 from ogcore.txfunc import *  # noqa: F403
 from ogcore.utils import *  # noqa: F403
 
-__version__ = "0.18.1"
+__version__ = "0.19.0"

--- a/ogcore/default_parameters.json
+++ b/ogcore/default_parameters.json
@@ -4079,6 +4079,50 @@
             }
         }
     },
+    "ndc_growth_rate": {
+        "title": "Growth rate applied to contributions under a notional defined contribution system.",
+        "description": "Growth rate applied to contributions under a notional defined contribution system.",
+        "section_1": "Fiscal Policy Parameters",
+        "section_2": "Government Pension Parameters",
+        "notes": "'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.",
+        "type": "str",
+        "value": [
+            {
+                "value": "LR GDP"
+            }
+        ],
+        "validators": {
+            "choice": {
+                "choices": [
+                    "r",
+                    "Curr GDP",
+                    "LR GDP"
+                ]
+            }
+        }
+    },
+    "dir_growth_rate": {
+        "title": "Growth rate used in the conversion coefficient of a notional defined contribution system.",
+        "description": "Growth rate used in the conversion coefficient of a notional defined contribution system.",
+        "section_1": "Fiscal Policy Parameters",
+        "section_2": "Government Pension Parameters",
+        "notes": "'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.",
+        "type": "str",
+        "value": [
+            {
+                "value": "LR GDP"
+            }
+        ],
+        "validators": {
+            "choice": {
+                "choices": [
+                    "r",
+                    "Curr GDP",
+                    "LR GDP"
+                ]
+            }
+        }
+    },
     "alpha_db": {
         "title": "Replacement rate under a defined contribution system.",
         "description": "Replacement rate under a defined contribution system.",
@@ -4114,6 +4158,28 @@
             "range": {
                 "min": 0.0,
                 "max": 1.0
+            }
+        }
+    },
+    "points_growth_rate": {
+        "title": "Growth rate applied to contributions under a points system pension.",
+        "description": "Growth rate applied to contributions under a points system pension.",
+        "section_1": "Fiscal Policy Parameters",
+        "section_2": "Government Pension Parameters",
+        "notes": "'r' uses the model interest rate, 'Curr GDP' the current GDP growth rate, and 'LR GDP' the long-run GDP growth rate.",
+        "type": "str",
+        "value": [
+            {
+                "value": "LR GDP"
+            }
+        ],
+        "validators": {
+            "choice": {
+                "choices": [
+                    "r",
+                    "Curr GDP",
+                    "LR GDP"
+                ]
             }
         }
     },

--- a/ogcore/pensions.py
+++ b/ogcore/pensions.py
@@ -730,14 +730,14 @@ def g_ndc(r, Y, p):
         g_ndc (Numpy array): growth rate used for contributions to NDC
 
     """
+    # r and g_y are scalars in the SS but paths in the TPI; take the
+    # last element robustly in either case (see Issue #1169)
     if p.ndc_growth_rate == "r":
-        g_ndc = r[-1]
+        g_ndc = np.asarray(r).flat[-1]
     elif p.ndc_growth_rate == "Curr GDP":
         g_ndc = (Y[1:] - Y[:-1]) / Y[:-1]
-    elif p.ndc_growth_rate == "LR GDP":
-        g_ndc = p.g_y[-1] + p.g_n[-1]
-    else:
-        g_ndc = p.g_y[-1] + p.g_n[-1]
+    else:  # "LR GDP"
+        g_ndc = np.asarray(p.g_y).flat[-1] + np.asarray(p.g_n).flat[-1]
 
     return g_ndc
 
@@ -757,14 +757,14 @@ def g_dir(r, Y, g_y, g_n, dir_growth_rate):
         g_dir (Numpy array): growth rate used for contributions to NDC
 
     """
+    # r and g_y are scalars in the SS but paths in the TPI; take the
+    # last element robustly in either case (see Issue #1169)
     if dir_growth_rate == "r":
-        g_dir = r[-1]
+        g_dir = np.asarray(r).flat[-1]
     elif dir_growth_rate == "Curr GDP":
         g_dir = (Y[1:] - Y[:-1]) / Y[:-1]
-    elif dir_growth_rate == "LR GDP":
-        g_dir = g_y[-1] + g_n[-1]
-    else:
-        g_dir = g_y[-1] + g_n[-1]
+    else:  # "LR GDP"
+        g_dir = np.asarray(g_y).flat[-1] + np.asarray(g_n).flat[-1]
 
     return g_dir
 
@@ -786,7 +786,14 @@ def delta_ret(r, Y, p):
             pension amount
 
     """
-    surv_rates = 1 - p.mort_rates_SS
+    # A real Specifications object has no mort_rates_SS attribute; fall
+    # back to the steady-state mortality rates implied by rho, averaged
+    # over lifetime-income groups with their population weights (see
+    # Issue #1169)
+    mort_rates_SS = getattr(p, "mort_rates_SS", None)
+    if mort_rates_SS is None:
+        mort_rates_SS = p.rho[-1] @ np.asarray(p.lambdas).ravel()
+    surv_rates = 1 - mort_rates_SS
     # Single retirement age for now (see Issue #1014)
     S_ret = int(np.asarray(p.retire).flat[-1])
     dir_delta_s_empty = np.zeros(p.S - S_ret + 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ogcore"
-version = "0.18.1"
+version = "0.19.0"
 authors = [
     {name = "Jason DeBacker and Richard W. Evans"},
 ]

--- a/tests/BENCHMARK_README.md
+++ b/tests/BENCHMARK_README.md
@@ -87,17 +87,17 @@ Each benchmark produces a `BenchmarkResult` with the following metrics:
 ```python
 @dataclass
 class BenchmarkResult:
-    test_name: str           # Name of the test
-    platform: str            # Operating system
-    scheduler: str           # Dask scheduler used
-    num_workers: int         # Number of workers
-    compute_time: float      # Execution time in seconds
-    peak_memory_mb: float    # Peak memory usage in MB
-    avg_memory_mb: float     # Average memory usage in MB
-    data_size_mb: float      # Input data size in MB
-    num_tasks: int           # Number of parallel tasks
-    success: bool            # Whether test succeeded
-    error_message: str       # Error details if failed
+    test_name: str  # Name of the test
+    platform: str  # Operating system
+    scheduler: str  # Dask scheduler used
+    num_workers: int  # Number of workers
+    compute_time: float  # Execution time in seconds
+    peak_memory_mb: float  # Peak memory usage in MB
+    avg_memory_mb: float  # Average memory usage in MB
+    data_size_mb: float  # Input data size in MB
+    num_tasks: int  # Number of parallel tasks
+    success: bool  # Whether test succeeded
+    error_message: str  # Error details if failed
 ```
 
 ### Key Metrics to Monitor
@@ -228,7 +228,7 @@ cluster = LocalCluster(
     n_workers=num_workers,
     threads_per_worker=2,
     processes=False,  # Use threads, not processes
-    memory_limit='4GB',
+    memory_limit="4GB",
 )
 client = Client(cluster)
 ```

--- a/tests/test_pensions.py
+++ b/tests/test_pensions.py
@@ -986,13 +986,20 @@ def test_get_PS(args, PS_expected):
             {"alpha_db": 0.02, "yr_contrib": 35, "avg_earn_num_years": 40},
         ),
         ("Points System", {"vpoint": 0.5}),
+        # The NDC growth-rate settings (ndc_growth_rate,
+        # dir_growth_rate) became parameters with Issue #1169; tau_p
+        # must be positive for the pension to be nonzero
+        (
+            "Notional Defined Contribution",
+            {
+                "tau_p": 0.1,
+                "ndc_growth_rate": "LR GDP",
+                "dir_growth_rate": "r",
+            },
+        ),
     ],
-    ids=["DB", "PS"],
+    ids=["DB", "PS", "NDC"],
 )
-# The Notional Defined Contribution system is excluded above: its
-# growth-rate settings (ndc_growth_rate, dir_growth_rate) are not yet
-# parameters in default_parameters.json, so it cannot run against a real
-# Specifications object at all.  See Issue #1169.
 def test_pension_amount_with_real_specifications(system, updates):
     """
     pension_amount must accept a real Specifications object in the SS:
@@ -1020,9 +1027,8 @@ def test_SS_solve_defined_benefits(tmp_path):
     """
     The steady state must solve with the Defined Benefits pension system
     and produce positive aggregate pension outlays (Issue #1014 asked for
-    model-run tests of each pension system; the NDC system cannot run yet
-    -- see above -- and the analogous Points System run should be added
-    with the resolution of that issue).
+    model-run tests of each pension system; the analogous NDC and Points
+    System runs should be added with the resolution of that issue).
     """
     from ogcore.execute import runner
     from ogcore import utils


### PR DESCRIPTION
Fixes #1169. Follow-up to #1167, which fixed the other two non-US pension systems.

The notional defined contribution pension system crashes as soon as you try to use it. Its growth-rate settings were never added to the parameters file, so the model stops with an error before computing anything. Behind that error sat two smaller bugs of the same kind: the growth-rate functions expect time paths but get single numbers in the steady state, and the benefit formula reads mortality rates from an attribute that only the unit tests ever set.

Changes:

- The growth-rate settings are now real parameters. The options are the interest rate, current GDP growth, or long-run GDP growth. The default is long-run GDP growth, which is what the code already fell back to, so existing runs are unchanged.
- The points system's growth-rate setting is added as a parameter too, since it has the same problem waiting.
- The growth-rate functions now work in both the steady state and on the transition path.
- The benefit formula uses the model's own mortality rates when the test-only attribute is missing.
- The NDC system is added to the test that runs each pension system on a real parameters object. The contribution rate must be set above its default of zero, or the pension is zero everywhere.

Tested: pension and parameter test suites pass, ruff clean. Bumps to 0.19.0 with a changelog entry.

cc @rickecon @jdebacker
