### PR TITLE
Fix unescaped backslash in theta label in model_variables.json

### DIFF
--- a/ogcore/model_variables.json
+++ b/ogcore/model_variables.json
@@ -527,7 +527,7 @@
         "type": "array-like",
         "TPI dimensions": "",
         "SS dimensions": "J",
-        "label": "Replacement rate ($\theta_j$)",
+        "label": "Replacement rate ($\\theta_j$)",
         "toGDP_label": ""
     },
     "factor": {

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,25 @@
+"""
+Tests of constants.py module and the label metadata loaded from
+model_variables.json.
+"""
+
+from ogcore import constants
+
+
+def test_labels_have_no_control_characters():
+    r"""
+    Guard against LaTeX label strings in model_variables.json being
+    written with a single backslash (e.g. "$\theta$"), which JSON parses
+    into a control character (a tab, in the case of "\t") and which then
+    fails to render in plots.  Backslashes must be escaped ("$\\theta$").
+    """
+    control_chars = set("\t\r\n\x08\x0c\x0b")
+    for label_map in (constants.VAR_LABELS, constants.ToGDP_LABELS):
+        for key, label in label_map.items():
+            assert isinstance(label, str)
+            bad = control_chars.intersection(label)
+            assert not bad, (
+                f"Label for {key!r} contains control character(s) "
+                f"{[c.encode('unicode_escape').decode() for c in bad]}: "
+                f"{label!r}. Escape backslashes in model_variables.json."
+            )


### PR DESCRIPTION
Closes #1015.

The `theta` label in `model_variables.json` was written with a single backslash:

```json
"label": "Replacement rate ($\theta_j$)",
```

JSON interprets `\t` as a tab character, so `\theta` parsed to `<TAB>heta` and the label failed to render as LaTeX in plots. This escapes the backslash so it parses to a literal `\theta`:

```json
"label": "Replacement rate ($\\theta_j$)",
```

This matches the convention already used by the other LaTeX labels in the file — the `\\tilde` labels for `c` and `p_tilde` were already written with escaped backslashes and render correctly. I went with escaping the JSON source (rather than casting to raw strings at read time, as the issue floated) because it's consistent with those existing labels and doesn't require any change to how `constants.py` loads the file. `theta` was the only remaining label with an unescaped backslash.

Also adds `tests/test_constants.py::test_labels_have_no_control_characters`, which asserts that no `VAR_LABELS`/`ToGDP_LABELS` entry contains a control character — guarding against this class of bug being reintroduced.

**Testing**
- `pytest tests/test_constants.py` passes; confirmed the test fails on the pre-fix JSON.
- Verified `VAR_LABELS["theta"] == "Replacement rate ($\\theta_j$)"` (literal backslash, no tab) and no other labels contain control characters.
- `ruff format --check .`, `ruff check .`, and `linecheck` clean.
