### PR TITLE
Add SS-solve model-run tests for NDC and Points System pension systems

### DIFF
--- a/tests/test_pensions.py
+++ b/tests/test_pensions.py
@@ -1048,3 +1048,55 @@ def test_SS_solve_defined_benefits(tmp_path):
     Y = np.asarray(ss["Y"]).sum()
     assert ss["agg_pension_outlays"] > 0.0
     assert 0.0 < ss["agg_pension_outlays"] / Y < 1.0
+
+
+@pytest.mark.local
+def test_SS_solve_notional_defined_contribution(tmp_path):
+    """
+    The steady state must solve with the Notional Defined Contribution
+    pension system and produce positive aggregate pension outlays (the
+    NDC counterpart to test_SS_solve_defined_benefits, Issue #1014).
+    """
+    from ogcore.execute import runner
+    from ogcore import utils
+
+    p = Specifications(baseline=True, num_workers=1)
+    p.update_specifications(
+        {
+            "pension_system": "Notional Defined Contribution",
+            "tau_p": 0.1,
+            "ndc_growth_rate": "LR GDP",
+            "dir_growth_rate": "r",
+        }
+    )
+    p.baseline_dir = p.output_base = str(tmp_path)
+    runner(p, time_path=False, client=None)
+    ss = utils.safe_read_pickle(str(tmp_path / "SS" / "SS_vars.pkl"))
+    Y = np.asarray(ss["Y"]).sum()
+    assert ss["agg_pension_outlays"] > 0.0
+    assert 0.0 < ss["agg_pension_outlays"] / Y < 1.0
+
+
+@pytest.mark.local
+def test_SS_solve_points_system(tmp_path):
+    """
+    The steady state must solve with the Points System pension system
+    and produce positive aggregate pension outlays (the Points System
+    counterpart to test_SS_solve_defined_benefits, Issue #1014).
+    """
+    from ogcore.execute import runner
+    from ogcore import utils
+
+    p = Specifications(baseline=True, num_workers=1)
+    p.update_specifications(
+        {
+            "pension_system": "Points System",
+            "vpoint": 0.5,
+        }
+    )
+    p.baseline_dir = p.output_base = str(tmp_path)
+    runner(p, time_path=False, client=None)
+    ss = utils.safe_read_pickle(str(tmp_path / "SS" / "SS_vars.pkl"))
+    Y = np.asarray(ss["Y"]).sum()
+    assert ss["agg_pension_outlays"] > 0.0
+    assert 0.0 < ss["agg_pension_outlays"] / Y < 1.0


### PR DESCRIPTION
Addresses part of #1014 (model-run tests for each pension system).

Following the merge of #1167 (which made the Defined Benefits system solve the steady state and transition path), Issue #1014 lists remaining work. Per @marcelolafleur's summary there, one of those items is TPI/SS-level model-run tests for each pension system — #1167 added a steady-state solve test for **Defined Benefits** only (`test_SS_solve_defined_benefits`), and its docstring notes the "analogous NDC and Points System runs should be added."

This PR adds those two missing steady-state solve tests:

- `test_SS_solve_notional_defined_contribution`
- `test_SS_solve_points_system`

Each mirrors `test_SS_solve_defined_benefits` exactly (same structure and assertions), using the same system-specific parameters already used in `test_pension_amount_with_real_specifications`. Each runs a full steady-state solve via `runner(p, time_path=False)` and asserts that aggregate pension outlays are positive and a sensible fraction of GDP. Both are marked `@pytest.mark.local`, consistent with the DB test.

**Scope note:** I deliberately kept this to test coverage and did **not** touch the pension formulas. The other open items in #1014 — time-varying retirement age and earnings profiles in the DB/NDC/PS formulas, and pre-time-path histories — are areas @marcelolafleur is actively working on (and OG-BRA depends on), so I didn't want to conflict with that. TPI-level run tests are a natural follow-up once the time-varying transition-path handling lands.

**Testing**
- `pytest tests/test_pensions.py -m local -k SS_solve` — all three pension-system SS solves pass (DB, NDC, Points System).
- `ruff format --check .`, `ruff check .`, and `linecheck` clean.
