### PR TITLE
Add Japan (392) and Fiji (242) to the offline demographics country map

### DIFF
--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -130,6 +130,7 @@ def get_un_data(
             "076": "BRA",
             "410": "KOR",
             "231": "ETH",
+            "392": "JPN",
         }
         un_variable_dict = {
             "68": "fertility_rates",

--- a/ogcore/demographics.py
+++ b/ogcore/demographics.py
@@ -131,6 +131,7 @@ def get_un_data(
             "410": "KOR",
             "231": "ETH",
             "392": "JPN",
+            "242": "FJI",
         }
         un_variable_dict = {
             "68": "fertility_rates",


### PR DESCRIPTION
Adds `"392": "JPN"` to the `country_dict` in `ogcore/demographics.py`, so the offline data fallback (used when no UN API token is present) can find Japan's demographic data by country code, like the other supported countries.

This pairs with **EAPD-DRB/Population-Data#14**, which adds the Japan data (`Data/JPN/`) to the mirror this fallback reads from. That PR should merge first; on its own this entry has no data behind it yet.

Motivation: I'm building an open-source OG model of Japan on top of OG-Core, and Japan is currently the only major economy without an OG country model. This (plus the data PR) lets OG-Core use Japan demographics offline. With a UN API token the live pull already works for Japan (code 392); this just extends the token-free path.
