### PR TITLE
Prepare release of  `ogcore` 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.2] - 2026-08-17 14:340:00
 
 ### Bug Fixes
 
@@ -754,6 +754,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Any earlier versions of OG-USA can be found in the [`OG-Core`](https://github.com/PSLmodels/OG-Core) repository [release history](https://github.com/PSLmodels/OG-Core/releases) from [v.0.6.4](https://github.com/PSLmodels/OG-Core/releases/tag/v0.6.4) (Jul. 20, 2021) or earlier.
 
 
+[0.19.2]: https://github.com/PSLmodels/OG-Core/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/PSLmodels/OG-Core/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/PSLmodels/OG-Core/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/PSLmodels/OG-Core/compare/v0.18.0...v0.18.1

--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -21,4 +21,4 @@ from ogcore.tax import *  # noqa: F403
 from ogcore.txfunc import *  # noqa: F403
 from ogcore.utils import *  # noqa: F403
 
-__version__ = "0.19.1"
+__version__ = "0.19.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ogcore"
-version = "0.19.1"
+version = "0.19.2"
 authors = [
     {name = "Jason DeBacker and Richard W. Evans"},
 ]


### PR DESCRIPTION
This PR prepares for the release of 0.19.2, a bug fix release.