### PR TITLE
Guard the Dask scatter in run_TPI so serial (client=None) runs work

### DIFF
--- a/ogcore/TPI.py
+++ b/ogcore/TPI.py
@@ -955,25 +955,26 @@ def run_TPI(p, client=None):
     trust_radius_max = getattr(p, "TPI_trust_radius_max", 10.0)
     prev_accel_dist = np.inf
 
-    # Before scattering, temporarily remove unpicklable schema objects
-    schema_backup = {}
-    for attr in ["_defaults_schema", "_validator_schema", "sel"]:
-        if hasattr(p, attr):
-            schema_backup[attr] = getattr(p, attr)
+    if client:
+        # Before scattering, temporarily remove unpicklable schema objects
+        schema_backup = {}
+        for attr in ["_defaults_schema", "_validator_schema", "sel"]:
+            if hasattr(p, attr):
+                schema_backup[attr] = getattr(p, attr)
+                try:
+                    delattr(p, attr)
+                except Exception:
+                    pass
+
+        # Scatter the parameters
+        scattered_p_future = client.scatter(p, broadcast=True)
+
+        # Restore the schema objects (they're not needed by workers anyway)
+        for attr, value in schema_backup.items():
             try:
-                delattr(p, attr)
+                setattr(p, attr, value)
             except Exception:
                 pass
-
-    # Scatter the parameters
-    scattered_p_future = client.scatter(p, broadcast=True)
-
-    # Restore the schema objects (they're not needed by workers anyway)
-    for attr, value in schema_backup.items():
-        try:
-            setattr(p, attr, value)
-        except Exception:
-            pass
 
     # TPI loop
     while (TPIiter < p.maxiter) and (TPIdist >= p.mindist_TPI):

--- a/tests/test_TPI.py
+++ b/tests/test_TPI.py
@@ -9,6 +9,7 @@ module contains the following tests:
     - test_run_TPI_full_run(), 11 parameterizations, local only
     - test_run_TPI(), 2 parameterizations, local only
     - test_run_TPI_extra(), 8 parameterizations, local only
+    - test_run_TPI_serial_no_client(), 1 parameterization
 """
 
 import multiprocessing
@@ -1206,3 +1207,49 @@ def test_run_TPI_extra(baseline, param_updates, filename, tmpdir, dask_client):
                 rtol=1e-04,
                 atol=1e-04,
             )
+
+
+class _ReachedTPILoop(Exception):
+    """Sentinel raised in place of the household inner loop."""
+
+
+def test_run_TPI_serial_no_client(tmpdir, monkeypatch):
+    """
+    Regression test: TPI.run_TPI(p, client=None) must reach the TPI loop.
+
+    run_TPI used to call ``client.scatter(p, broadcast=True)``
+    unconditionally, so passing ``client=None`` raised an
+    ``AttributeError`` before the TPI loop was ever entered, making the
+    serial fallback inside the loop unreachable.  This test does not
+    solve a transition path: it seeds the baseline SS results from the
+    cached pickles in ``test_io_data`` and monkeypatches
+    ``TPI.inner_loop`` to raise a sentinel, so it asserts only that
+    execution gets as far as the first serial household solve.
+    """
+    # Seed cached baseline SS results so no SS solve is needed
+    old_baseline_dir = os.path.join(CUR_PATH, "test_io_data", "OUTPUT2")
+    ss_vars = utils.safe_read_pickle(
+        os.path.join(old_baseline_dir, "SS", "SS_vars.pkl")
+    )
+    ss_vars_new = {SS_VAR_NAME_MAPPING[k]: v for k, v in ss_vars.items()}
+    baseline_dir = os.path.join(tmpdir, "baseline")
+    utils.mkdirs(os.path.join(baseline_dir, "SS"))
+    with open(os.path.join(baseline_dir, "SS", "SS_vars.pkl"), "wb") as f:
+        pickle.dump(ss_vars_new, f)
+
+    p = Specifications(
+        baseline=True,
+        baseline_dir=baseline_dir,
+        output_base=baseline_dir,
+        num_workers=1,
+    )
+    p.update_specifications(TEST_PARAM_DICT.copy())
+    p.maxiter = 1
+
+    def mock_inner_loop(*args, **kwargs):
+        raise _ReachedTPILoop()
+
+    monkeypatch.setattr(TPI, "inner_loop", mock_inner_loop)
+
+    with pytest.raises(_ReachedTPILoop):
+        TPI.run_TPI(p, client=None)


### PR DESCRIPTION
## Why

`run_TPI(p, client=None)` crashes. `client.scatter` is called unconditionally, so passing no Dask client raises `AttributeError` before the TPI loop is entered — which makes the serial fallback at `TPI.py:1039` unreachable in exactly the case it exists for. `SS.inner_loop` already guards the equivalent block with `if client:`; TPI doesn't.

## What changes after merging

Serial TPI runs work. Anyone calling `run_TPI` without a Dask cluster — scripts, notebooks, CI, small debugging runs — goes from a hard crash to a working solve. No behaviour changes when a client is supplied.

## Change

Wraps the schema-backup / scatter / restore block in `if client:`. `scattered_p_future` is only read inside the `if client:` submit branch, so this is a guard plus an indent — no logic moves.

## Evidence

New `tests/test_TPI.py::test_run_TPI_serial_no_client` seeds SS from the cached `test_io_data` pickles and monkeypatches `inner_loop` to raise a sentinel, asserting execution reaches the first serial household solve. No solve is run; ~1s, no Dask, so it is unmarked and guards this path in normal CI.

```
with the fix:      1 passed in 1.15s
fix stashed:       FAILED - AttributeError: 'NoneType' object has no attribute 'scatter'
```

Fixes the first half of #1211. The second half (SS re-scattering per residual evaluation) is #1214.
